### PR TITLE
Updated ubo-core to latest version

### DIFF
--- a/packages/adblocker-benchmarks/Makefile
+++ b/packages/adblocker-benchmarks/Makefile
@@ -29,7 +29,7 @@ requests.json:
 	curl -O --compressed https://raw.githubusercontent.com/mjethani/scaling-palm-tree/06ef031aa3d2742dc7e6234f579e28a9b6d499b0/requests.json
 
 ./node_modules/@gorhill/ubo-core:
-	npm install --no-save @gorhill/ubo-core@0.1.7
+	npm install --no-save @gorhill/ubo-core@0.1.14
 	npx rollup ./node_modules/@gorhill/ubo-core/index.js \
 		--file ./node_modules/@gorhill/ubo-core/bundle.min.cjs --format cjs \
 		--context global --plugin terser

--- a/packages/adblocker-benchmarks/package.json
+++ b/packages/adblocker-benchmarks/package.json
@@ -27,7 +27,7 @@
   },
   "peerDependencies": {
     "@adguard/tsurlfilter": "0.7.26",
-    "@gorhill/ubo-core": "0.1.7",
+    "@gorhill/ubo-core": "0.1.14",
     "adblock-rs": "0.3.15",
     "adblockpluscore": "0.3.1",
     "fast-hosts-lookup": "github:mjethani/fast-hosts-lookup#9136bb8c331ee5dba8ac1a0018552cace11e2afa"


### PR DESCRIPTION
This patch is to update `ubo-core` to [latest version 0.1.14 on npm](https://www.npmjs.com/package/@gorhill/ubo-core).