### PR TITLE
Update Puppeteer Cooperative Intercept Mode

### DIFF
--- a/packages/adblocker-puppeteer-example/package.json
+++ b/packages/adblocker-puppeteer-example/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@cliqz/adblocker-puppeteer": "^1.23.1",
     "node-fetch": "^3.0.0",
-    "puppeteer": "11.0.0",
+    "puppeteer": "13.0.0",
     "ts-node": "^10.0.0"
   },
   "devDependencies": {

--- a/packages/adblocker-puppeteer/adblocker.ts
+++ b/packages/adblocker-puppeteer/adblocker.ts
@@ -283,7 +283,12 @@ export class PuppeteerBlocker extends FiltersEngine {
     (this.priority = defaultPriority);
 
   public onRequest = (details: puppeteer.HTTPRequest): void => {
+    if (details.isInterceptResolutionHandled?.()) {
+      return;
+    }
+
     const request = fromPuppeteerDetails(details);
+
     if (this.config.guessRequestTypeFromUrl === true && request.type === 'other') {
       request.guessTypeOfRequest();
     }
@@ -294,7 +299,7 @@ export class PuppeteerBlocker extends FiltersEngine {
       request.isMainFrame() ||
       (request.type === 'document' && frame !== null && frame.parentFrame() === null)
     ) {
-      details.continue(details.continueRequestOverrides(), this.priority);
+      details.continue(details.continueRequestOverrides?.(), 0);
       return;
     }
 
@@ -325,7 +330,7 @@ export class PuppeteerBlocker extends FiltersEngine {
     } else if (match === true) {
       details.abort('blockedbyclient', this.priority);
     } else {
-      details.continue(details.continueRequestOverrides(), this.priority);
+      details.continue(details.continueRequestOverrides?.(), 0);
     }
   };
 

--- a/packages/adblocker-puppeteer/package.json
+++ b/packages/adblocker-puppeteer/package.json
@@ -34,7 +34,7 @@
     "url": "https://github.com/cliqz-oss/adblocker/issues"
   },
   "peerDependencies": {
-    "puppeteer": "5.x || 6.x || 7.x || 8.x || 9.x || 10.x || 11.x"
+    "puppeteer": "5.x || 6.x || 7.x || 8.x || 9.x || 10.x || 11.x || 12.x || 13.x"
   },
   "dependencies": {
     "@cliqz/adblocker": "^1.23.1",
@@ -47,7 +47,7 @@
     "chai": "^4.2.0",
     "mocha": "^9.0.0",
     "nyc": "^15.0.0",
-    "puppeteer": "11.0.0",
+    "puppeteer": "13.0.0",
     "rimraf": "^3.0.0",
     "ts-node": "^10.0.0",
     "tslint": "^6.0.0",
@@ -91,6 +91,10 @@
     {
       "name": "Konstantin Mosunov",
       "email": "mosunov.konstantin@huawei.com"
+    },
+    {
+      "name": "Rodrigo Fernández",
+      "email": "fdezromero@users.noreply.github.com"
     }
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2797,10 +2797,10 @@ detect-node@^2.0.4:
   resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.1.0.tgz#c9c70775a49c3d03bc2c06d9a73be550f978f8b1"
   integrity sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==
 
-devtools-protocol@0.0.901419:
-  version "0.0.901419"
-  resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.901419.tgz#79b5459c48fe7e1c5563c02bd72f8fec3e0cebcd"
-  integrity sha512-4INMPwNm9XRpBukhNbF7OB6fNTTCaI8pzy/fXg0xQzAy5h3zL1P8xT3QazgKqBrb/hAYwIBizqDBZ7GtJE74QQ==
+devtools-protocol@0.0.937139:
+  version "0.0.937139"
+  resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.937139.tgz#bdee3751fdfdb81cb701fd3afa94b1065dafafcf"
+  integrity sha512-daj+rzR3QSxsPRy5vjjthn58axO8c11j58uY0lG5vvlJk/EiOdCWOptGdkXDjtuRHr78emKq0udHCXM4trhoDQ==
 
 dezalgo@^1.0.0:
   version "1.0.3"
@@ -5818,13 +5818,13 @@ punycode@^2.1.0, punycode@^2.1.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
-puppeteer@11.0.0:
-  version "11.0.0"
-  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-11.0.0.tgz#0808719c38e15315ecc1b1c28911f1c9054d201f"
-  integrity sha512-6rPFqN1ABjn4shgOICGDBITTRV09EjXVqhDERBDKwCLz0UyBxeeBH6Ay0vQUJ84VACmlxwzOIzVEJXThcF3aNg==
+puppeteer@13.0.0:
+  version "13.0.0"
+  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-13.0.0.tgz#f241d9bbbe5c8388da922f4f6ea3f84866e17f81"
+  integrity sha512-kZfGAieIVSo4bFqYuvY2KvhgP9txzmPbbnpZIzLlfdt8nEu9evXEwsbBt1BHocVQM4fJmCiS+FRyw7c8aWadNg==
   dependencies:
     debug "4.3.2"
-    devtools-protocol "0.0.901419"
+    devtools-protocol "0.0.937139"
     extract-zip "2.0.1"
     https-proxy-agent "5.0.0"
     node-fetch "2.6.5"


### PR DESCRIPTION
Updates #2281 with:
- Puppeteer v13.0.0
- New check for already handled requests in Legacy Mode
- Fix for breaking changes with `continueRequestOverrides()`

Related to https://github.com/berstend/puppeteer-extra/pull/592