### PR TITLE
CI: fix dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,12 @@
 version: 2
 updates:
-- package-ecosystem: npm
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "04:00"
-  open-pull-requests-limit: 99
-  reviewers:
-  - remusao
-  labels:
-  - "PR: Dependencies :nut_and_bolt:"
-  automerged_updates:
-    - match:
-        dependency_type: "all"
-        update_type: "all"
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "04:00"
+    open-pull-requests-limit: 99
+    reviewers:
+      - remusao
+    labels:
+      - "PR: Dependencies :nut_and_bolt:"


### PR DESCRIPTION
automerge does not seem to be possible anymore. Dependapot complained:
```
The property '#/updates/0/' contains additional properties ["automerged_updates"] outside of the schema when none are allowed
```