### PR TITLE
CI: commit asset updates with Bot identity

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -56,6 +56,7 @@ jobs:
         with:
           token: ${{ steps.generate-token.outputs.token }}
           committer: Ghostery Adblocker Bot <ghostery-adblocker-bot@users.noreply.github.com>
+          author: Ghostery Adblocker Bot <ghostery-adblocker-bot@users.noreply.github.com>
           commit-message: "Update local assets and compression codebooks"
           title: "Update local assets"
           body: "Automated update of local assets and compression codebooks."


### PR DESCRIPTION
Commiter is properly set, but for some reason the Author is being used. Lets see if changing the author will fix the issue. 
https://github.com/peter-evans/create-pull-request/blob/main/src/create-pull-request.ts#L162