### PR TITLE
Stop removing is-mutation-observer-enabled

### DIFF
--- a/packages/adblocker-electron/adblocker.ts
+++ b/packages/adblocker-electron/adblocker.ts
@@ -110,7 +110,6 @@ export class BlockingContext {
     if (this.blocker.config.loadCosmeticFilters === true) {
       this.session.setPreloads(this.session.getPreloads().filter((p) => p !== PRELOAD_PATH));
       ipcMain.removeListener('get-cosmetic-filters', this.onGetCosmeticFilters);
-      ipcMain.removeListener('is-mutation-observer-enabled', this.onIsMutationObserverEnabled);
     }
   }
 }


### PR DESCRIPTION
This prevents sendSync from locking the application when no listener is available.