### PR TITLE
cosmetics: make sure we do not hide body or html elements

### DIFF
--- a/packages/adblocker-content/adblocker.ts
+++ b/packages/adblocker-content/adblocker.ts
@@ -63,9 +63,7 @@ function getElementsFromMutations(mutations: MutationRecord[]): Element[] {
  * potentially be injected in content-script (e.g.: see PuppeteerBlocker for
  * more details).
  */
-export function extractFeaturesFromDOM(
-  roots: Element[],
-): {
+export function extractFeaturesFromDOM(roots: Element[]): {
   classes: string[];
   hrefs: string[];
   ids: string[];
@@ -77,7 +75,12 @@ export function extractFeaturesFromDOM(
   const ids: Set<string> = new Set();
 
   for (const root of roots) {
-    for (const element of [root, ...root.querySelectorAll('[id],[class],[href]')]) {
+    for (const element of [
+      root,
+      ...root.querySelectorAll(
+        '[id]:not(html):not(body),[class]:not(html):not(body),[href]:not(html):not(body)',
+      ),
+    ]) {
       if (ignoredTags.has(element.nodeName.toLowerCase())) {
         continue;
       }

--- a/packages/adblocker-webextension-cosmetics/adblocker.ts
+++ b/packages/adblocker-webextension-cosmetics/adblocker.ts
@@ -165,7 +165,7 @@ function updateExtended() {
 
 /**
  * Queue `elements` to be processed asynchronously in a batch way (for
- * efficiency).  This is important to not do more work than necessary, for
+ * efficiency). This is important to not do more work than necessary, for
  * example if the same set of nodes is updated multiple times in a raw on
  * user-interaction (e.g. a dropdown); this allows to only check these nodes
  * once, and to not block the UI.


### PR DESCRIPTION
Related to https://github.com/ghostery/ghostery-extension/issues/761

The idea here is to not apply generic filters which would target the `html` or `body` elements directly. The change does not guarantee that it will never happen, but it should at least not happen so often.