### PR TITLE
Don't run assets updates on forks.

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -9,6 +9,7 @@ jobs:
   assets:
     name: Update local assets
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'ghostery'
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
This cron fails on forks by default since they don't have the proper
secrets configured.  This is a bit annoying and a waste of CPU cycles since
it really only needs to be run on the core repo.