### PR TITLE
Move ublock/annoyances.txt to the Ad + Tracking + Annoyances list

### DIFF
--- a/packages/adblocker/src/fetch.ts
+++ b/packages/adblocker/src/fetch.ts
@@ -56,7 +56,6 @@ export const adsLists = [
   `${PREFIX}/easylist/easylist.txt`,
   `${PREFIX}/easylist/easylistgermany.txt`,
   `${PREFIX}/peter-lowe/serverlist.txt`,
-  `${PREFIX}/ublock-origin/annoyances.txt`,
   `${PREFIX}/ublock-origin/badware.txt`,
   `${PREFIX}/ublock-origin/filters.txt`,
   `${PREFIX}/ublock-origin/filters-2020.txt`,
@@ -72,7 +71,11 @@ export const adsAndTrackingLists = [
   `${PREFIX}/ublock-origin/privacy.txt`,
 ];
 
-export const fullLists = [...adsAndTrackingLists, `${PREFIX}/easylist/easylist-cookie.txt`];
+export const fullLists = [
+  ...adsAndTrackingLists,
+  `${PREFIX}/easylist/easylist-cookie.txt`,
+  `${PREFIX}/ublock-origin/annoyances.txt`,
+];
 
 /**
  * Fetch latest version of enabledByDefault blocking lists.


### PR DESCRIPTION
Annoyances get blocked when the level is set to Only Ads. This moves the unlock annoyances List into the "Ads + Trackers + Annoyances" array from the "Ads Only" array.

Tangentially Related to https://github.com/ghostery/ghostery-extension/pull/752