### PR TITLE
Fix resolving the promise if there is no scripts to inject

### DIFF
--- a/packages/adblocker-webextension/adblocker.ts
+++ b/packages/adblocker-webextension/adblocker.ts
@@ -402,10 +402,12 @@ export class WebExtensionBlocker extends FiltersEngine {
           scripts,
           styles: '',
         });
+        return;
       }
     }
 
     await Promise.all(promises);
+    sendResponse();
   };
 
   /**


### PR DESCRIPTION
Fixes https://github.com/ghostery/ghostery-extension/issues/806. Related to try of fix in `ghostery-common` in https://github.com/ghostery/common/pull/47.

The PR fixes a case, where the promise is not resolved nor rejected. I think it was not intentional, as the last line of the function contains `await Promise.all(...` which is useless as the returned promise from the function is not used, but the promise generated by hand).

However, the PR changes the logic, so the promise (and returned response from the event) is now always resolved after those promises resolve. @remusao please take a look, as you make the last changes in that part.