### PR TITLE
Proof-of-concept how to block YouTube ads.

### DIFF
--- a/packages/adblocker-webextension-example/manifest.json
+++ b/packages/adblocker-webextension-example/manifest.json
@@ -8,6 +8,7 @@
     "48": "cliqz.png"
   },
   "permissions": [
+    "webNavigation",
     "webRequest",
     "webRequestBlocking",
     "tabs",


### PR DESCRIPTION
Background: the current mechanism to inject scriptlets by asynchronously responding to messages from the content script is not reliable. Because of the asynchronous communication, it is possible that the website already executed and the patching is too late.

A more reliable approach is to use the "tabs.executeScript" API and to use the webNavigation.onCommitted hook to trigger it.