### PR TITLE
New option "enablePushInjectionsOnNavigationEvents"

### DIFF
--- a/packages/adblocker-webextension-example/manifest.json
+++ b/packages/adblocker-webextension-example/manifest.json
@@ -8,6 +8,7 @@
     "48": "cliqz.png"
   },
   "permissions": [
+    "webNavigation",
     "webRequest",
     "webRequestBlocking",
     "tabs",

--- a/packages/adblocker-webextension/adblocker.ts
+++ b/packages/adblocker-webextension/adblocker.ts
@@ -71,6 +71,7 @@ function usePushScriptsInjection() {
   // on Firefox, the same steps do not seem to trigger any ads.
   return !isFirefox();
 }
+const USE_PUSH_SCRIPTS_INJECTION = usePushScriptsInjection();
 
 /**
  * Create an instance of `Request` from WebRequest details.
@@ -221,7 +222,7 @@ export class BlockingContext {
 
     if (
       this.blocker.config.enablePushInjectionsOnNavigationEvents === true &&
-      usePushScriptsInjection()
+      USE_PUSH_SCRIPTS_INJECTION
     ) {
       if (this.browser.webNavigation?.onCommitted) {
         this.onCommittedHandler = (details) => blocker.onCommittedHandler(browser, details);

--- a/packages/adblocker/src/config.ts
+++ b/packages/adblocker/src/config.ts
@@ -52,7 +52,7 @@ export default class Config {
     enableInMemoryCache = true,
     enableMutationObserver = true,
     enableOptimizations = true,
-    enablePushInjectionsOnNavigationEvents = false,
+    enablePushInjectionsOnNavigationEvents = true,
     guessRequestTypeFromUrl = false,
     integrityCheck = true,
     loadCSPFilters = true,

--- a/packages/adblocker/src/config.ts
+++ b/packages/adblocker/src/config.ts
@@ -17,6 +17,7 @@ export default class Config {
       enableInMemoryCache: buffer.getBool(),
       enableMutationObserver: buffer.getBool(),
       enableOptimizations: buffer.getBool(),
+      enablePushInjectionsOnNavigationEvents: buffer.getBool(),
       guessRequestTypeFromUrl: buffer.getBool(),
       integrityCheck: buffer.getBool(),
       loadCSPFilters: buffer.getBool(),
@@ -34,6 +35,7 @@ export default class Config {
   public readonly enableInMemoryCache: boolean;
   public readonly enableMutationObserver: boolean;
   public readonly enableOptimizations: boolean;
+  public readonly enablePushInjectionsOnNavigationEvents: boolean;
   public readonly guessRequestTypeFromUrl: boolean;
   public readonly integrityCheck: boolean;
   public readonly loadCSPFilters: boolean;
@@ -50,6 +52,7 @@ export default class Config {
     enableInMemoryCache = true,
     enableMutationObserver = true,
     enableOptimizations = true,
+    enablePushInjectionsOnNavigationEvents = false,
     guessRequestTypeFromUrl = false,
     integrityCheck = true,
     loadCSPFilters = true,
@@ -65,6 +68,7 @@ export default class Config {
     this.enableInMemoryCache = enableInMemoryCache;
     this.enableMutationObserver = enableMutationObserver;
     this.enableOptimizations = enableOptimizations;
+    this.enablePushInjectionsOnNavigationEvents = enablePushInjectionsOnNavigationEvents;
     this.guessRequestTypeFromUrl = guessRequestTypeFromUrl;
     this.integrityCheck = integrityCheck;
     this.loadCSPFilters = loadCSPFilters;
@@ -78,7 +82,7 @@ export default class Config {
   public getSerializedSize(): number {
     // NOTE: this should always be the number of attributes and needs to be
     // updated when `Config` changes.
-    return 14 * sizeOfBool();
+    return 15 * sizeOfBool();
   }
 
   public serialize(buffer: StaticDataView): void {
@@ -88,6 +92,7 @@ export default class Config {
     buffer.pushBool(this.enableInMemoryCache);
     buffer.pushBool(this.enableMutationObserver);
     buffer.pushBool(this.enableOptimizations);
+    buffer.pushBool(this.enablePushInjectionsOnNavigationEvents);
     buffer.pushBool(this.guessRequestTypeFromUrl);
     buffer.pushBool(this.integrityCheck);
     buffer.pushBool(this.loadCSPFilters);


### PR DESCRIPTION
The original method of having the content script pull the scriptlets introduces extra latency, which becomes a problem on Chrome-based browsers. A prominent example is YouTube, where the scriptlets sometimes get executed when the site's JavaScript has already run. A more reliable mechanism is to use "webNavigation.onCommitted" API as a hook and "push" the injections through the "tabs.executeScript" API.

The new option is opt-in, but according to the tests it is recommended for clients to enable it at least for Chromium-based browsers. On Firefox, there is currently no proof that it is required to use it.

---

It is a follow-up of https://github.com/ghostery/adblocker/pull/2725. To try it out in the example extension, you need to enable it first:

```
diff --git a/packages/adblocker-webextension-example/background.ts b/packages/adblocker-webextension-example/background.ts
index a269233f..83af1019 100644
--- a/packages/adblocker-webextension-example/background.ts
+++ b/packages/adblocker-webextension-example/background.ts
@@ -59,6 +59,8 @@ WebExtensionBlocker.fromLists(fetch, fullLists, {
   enableCompression: true,
   enableHtmlFiltering: true,
   loadExtendedSelectors: true,
+  enablePushInjectionsOnNavigationEvents: true,
+  debug: true,
 }).then((blocker: WebExtensionBlocker) => {
   blocker.enableBlockingInBrowser(browser);
 
diff --git a/packages/adblocker-webextension-example/manifest.json b/packages/adblocker-webextension-example/manifest.json
index 731f8963..c558e1ff 100644
--- a/packages/adblocker-webextension-example/manifest.json
+++ b/packages/adblocker-webextension-example/manifest.json
@@ -8,6 +8,7 @@
     "48": "cliqz.png"
   },
   "permissions": [
+    "webNavigation",
     "webRequest",
     "webRequestBlocking",
     "tabs",
```