### PR TITLE
Preserve all information in rawLine (fix for the blank screen in YouTube full screen mode)

### DIFF
--- a/packages/adblocker/src/filters/cosmetic.ts
+++ b/packages/adblocker/src/filters/cosmetic.ts
@@ -179,6 +179,8 @@ export default class CosmeticFilter implements IFilter {
    * used to parse tens of thousands of lines.
    */
   public static parse(line: string, debug: boolean = false): CosmeticFilter | null {
+    const rawLine = line;
+
     // Mask to store attributes. Each flag (unhide, scriptInject, etc.) takes
     // only 1 bit at a specific offset defined in COSMETICS_MASK.
     // cf: COSMETICS_MASK for the offset of each property
@@ -352,7 +354,7 @@ export default class CosmeticFilter implements IFilter {
 
     return new CosmeticFilter({
       mask,
-      rawLine: debug === true ? line : undefined,
+      rawLine: debug === true ? rawLine : undefined,
       selector,
       style,
       domains,


### PR DESCRIPTION
For instance,
`youtube.com##.no-scroll #page-manager:style(margin-top: 0px !important)`

should not be reduced to
`youtube.com##.no-scroll #page-manager`

Using `line` is problematic since it is modified during processing.

Note that this is not only relevant for debugging, but can have impact in production (if lists need to be dynamically built):
https://github.com/ghostery/adblocker/blob/f4c7ce4a3c6484bc7ee83d023b6f7f00f91f8e64/packages/adblocker/src/lists.ts#L235 