### PR TITLE
Use "pagehide" instead of "unload"

### DIFF
--- a/packages/adblocker-webextension-cosmetics/adblocker.ts
+++ b/packages/adblocker-webextension-cosmetics/adblocker.ts
@@ -291,5 +291,5 @@ export function injectCosmetics(
     { once: true, passive: true },
   );
 
-  window.addEventListener('unload', unload, { once: true, passive: true });
+  window.addEventListener('pagehide', unload, { once: true, passive: true });
 }


### PR DESCRIPTION
Follows the recommendation to use "pagehide" instead of "unload"
https://web.dev/bfcache/#never-use-the-unload-event

refs https://github.com/ghostery/ghostery-extension/issues/836