### PR TITLE
[adblocker-playwright] Await route

### DIFF
--- a/packages/adblocker-playwright/adblocker.ts
+++ b/packages/adblocker-playwright/adblocker.ts
@@ -77,7 +77,7 @@ export class BlockingContext {
       //  easily be added if Playwright implements the required capability.
       //
       // Register callback for network requests filtering.
-      this.page.route('**/*', this.onRequest);
+      await this.page.route('**/*', this.onRequest);
     }
   }
 


### PR DESCRIPTION
Add an `await` for the [`Page.route()`](https://playwright.dev/docs/api/class-page#page-route) method of Playwright that returns a promise.