### PR TITLE
Adjust scriptlet injection timing

### DIFF
--- a/packages/adblocker-electron-preload/preload.ts
+++ b/packages/adblocker-electron-preload/preload.ts
@@ -60,7 +60,9 @@ if (window === window.top && window.location.href.startsWith('devtools://') === 
           (document.head || document.documentElement || document).appendChild(e);
           elems.push(e);
         });
-      } catch (ex) {}
+      } catch {
+        // continue regardless of error
+      }
       elems.forEach((removeIt) => {
         removeIt.remove();
         removeIt.textContent = '';


### PR DESCRIPTION
## Release Notes

Resolves https://github.com/ghostery/adblocker/issues/2757

Changed the timing of scriptlet injection to before the DOMContentLoaded event fires. Also changed the injection method from using Electron.WebContents.executeJavaScript (which is effectively executed when the tab finishes loading) to dynamically adding a script element, similar to how μBlock Origin does it.