### PR TITLE
:bug: remove unnecessary setImmediate method

### DIFF
--- a/packages/adblocker-electron-preload/preload.ts
+++ b/packages/adblocker-electron-preload/preload.ts
@@ -14,9 +14,7 @@ function getCosmeticsFiltersFirst(): string[] | null {
   return ipcRenderer.sendSync('get-cosmetic-filters-first', window.location.href);
 }
 function getCosmeticsFiltersUpdate(data: Omit<IBackgroundCallback, 'lifecycle'>) {
-  setImmediate(() => {
-    ipcRenderer.send('get-cosmetic-filters', window.location.href, data);
-  });
+  ipcRenderer.send('get-cosmetic-filters', window.location.href, data);
 }
 
 if (window === window.top && window.location.href.startsWith('devtools://') === false) {


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/Window/setImmediate#browser_compatibility
setImmediate cannot be used in browsers, and since there is no longer a need to delay execution, it has been removed.