### PR TITLE
Improve timing of scriptlet injection

### DIFF
--- a/packages/adblocker-webextension-cosmetics/adblocker.ts
+++ b/packages/adblocker-webextension-cosmetics/adblocker.ts
@@ -219,11 +219,13 @@ function handleResponseFromBackground(
 
   // Inject scripts
   if (scripts) {
-    setTimeout(() => {
+    try {
       for (const script of scripts) {
         injectScript(script, window.document);
       }
-    }, 0);
+    } catch (e) {
+      // continue regardless of error
+    }
   }
 
   // Extended CSS

--- a/packages/adblocker-webextension-cosmetics/adblocker.ts
+++ b/packages/adblocker-webextension-cosmetics/adblocker.ts
@@ -219,12 +219,12 @@ function handleResponseFromBackground(
 
   // Inject scripts
   if (scripts) {
-    try {
-      for (const script of scripts) {
+    for (const script of scripts) {
+      try {
         injectScript(script, window.document);
+      } catch (e) {
+        // continue regardless of error
       }
-    } catch (e) {
-      // continue regardless of error
     }
   }
 


### PR DESCRIPTION
Some scriptlets like `set-constant` or `json-prune` benefit from being injected ASAP.  One very concrete example is YouTube adblocking which fails with any additional delays are introduced.

fix https://github.com/ghostery/broken-page-reports/issues/267