### PR TITLE
Fix electron blocker performance regression

### DIFF
--- a/packages/adblocker-content/adblocker.ts
+++ b/packages/adblocker-content/adblocker.ts
@@ -260,7 +260,7 @@ export function injectScript(s: string, doc: Document): void {
   script.appendChild(doc.createTextNode(autoRemoveScript(s)));
 
   // Insert node
-  const parent = doc.head || doc.documentElement;
+  const parent = doc.head || doc.documentElement || doc;
   if (parent !== null) {
     parent.appendChild(script);
   }

--- a/packages/adblocker-electron-preload/preload.ts
+++ b/packages/adblocker-electron-preload/preload.ts
@@ -8,7 +8,12 @@
 
 import { ipcRenderer } from 'electron';
 
-import { DOMMonitor, IBackgroundCallback, IMessageFromBackground } from '@cliqz/adblocker-content';
+import {
+  DOMMonitor,
+  IBackgroundCallback,
+  IMessageFromBackground,
+  injectScript,
+} from '@cliqz/adblocker-content';
 
 function getCosmeticsFiltersFirst(): string[] | null {
   return ipcRenderer.sendSync('get-cosmetic-filters-first', window.location.href);
@@ -50,21 +55,9 @@ if (window === window.top && window.location.href.startsWith('devtools://') === 
 
     const scripts = getCosmeticsFiltersFirst();
     if (scripts) {
-      const elems: HTMLScriptElement[] = [];
-      try {
-        scripts.forEach((script) => {
-          const e = document.createElement('script');
-          e.appendChild(document.createTextNode(script));
-          (document.head || document.documentElement || document).appendChild(e);
-          elems.push(e);
-        });
-      } catch {
-        // continue regardless of error
+      for (const script of scripts) {
+        injectScript(script, document);
       }
-      elems.forEach((removeIt) => {
-        removeIt.remove();
-        removeIt.textContent = '';
-      });
     }
 
     // On DOMContentLoaded, start monitoring the DOM. This means that we will

--- a/packages/adblocker-electron/adblocker.ts
+++ b/packages/adblocker-electron/adblocker.ts
@@ -183,6 +183,7 @@ export class ElectronBlocker extends FiltersEngine {
       getInjectionRules: true,
       getExtendedRules: true,
       getRulesFromHostname: true,
+      getRulesFromDOM: false, // Only done on updates (see `onGetCosmeticFiltersUpdated`)
     });
 
     if (active === false) {
@@ -221,6 +222,12 @@ export class ElectronBlocker extends FiltersEngine {
       classes: msg.classes,
       hrefs: msg.hrefs,
       ids: msg.ids,
+
+      // Only done on first load in the frame, disable for updates
+      getBaseRules: false,
+      getInjectionRules: false,
+      getExtendedRules: false,
+      getRulesFromHostname: false,
 
       // This will be done every time we get information about DOM mutation
       getRulesFromDOM: true,


### PR DESCRIPTION
Fixes https://github.com/ghostery/adblocker/issues/3420

In https://github.com/ghostery/adblocker/pull/3162 we split the call to get scriptlets and styles to inject into two different listeners. The one that is called on updates needs to explicitly disable the base styles otherwise we keep re-injecting a massive stylesheet on any DOM update.