### PR TITLE
Scriptlets: inject quoted arguments without quotes

### DIFF
--- a/packages/adblocker/src/filters/cosmetic.ts
+++ b/packages/adblocker/src/filters/cosmetic.ts
@@ -748,7 +748,17 @@ export default class CosmeticFilter implements IFilter {
       return undefined;
     }
 
-    return { name: parts[0], args: parts.slice(1) };
+    const args = parts.slice(1).map((part) => {
+      if (
+        (part.startsWith(`'`) && part.endsWith(`'`)) ||
+        (part.startsWith(`"`) && part.endsWith(`"`))
+      ) {
+        return part.substring(1, part.length - 1);
+      }
+      return part;
+    });
+
+    return { name: parts[0], args };
   }
 
   public getScript(js: Map<string, string>): string | undefined {

--- a/packages/adblocker/test/parsing.test.ts
+++ b/packages/adblocker/test/parsing.test.ts
@@ -2023,11 +2023,11 @@ describe('scriptlets arguments parsing', () => {
         { name: 'acis', args: ['document.createElement', '/break;case $.|popunder/'] },
       ],
       ['acs, atob, -0x1', { name: 'acs', args: ['atob', '-0x1'] }],
-      ["acs, atob, 'shift'", { name: 'acs', args: ['atob', "'shift'"] }],
+      ["acs, atob, 'shift'", { name: 'acs', args: ['atob', 'shift'] }],
       ["acs, Date, ='\\x", { name: 'acs', args: ['Date', "='\\x"] }],
       [
         `acs, decodeURIComponent, "'shift'"`,
-        { name: 'acs', args: ['decodeURIComponent', `"'shift'"`] },
+        { name: 'acs', args: ['decodeURIComponent', `'shift'`] },
       ],
       [
         `acs, document.getElementById, /\\$\\('body'\\)|\\$\\("body"\\)/`,
@@ -2054,6 +2054,17 @@ describe('scriptlets arguments parsing', () => {
     ).to.eql({
       name: 'script-name',
       args: ['', '', 'foo', '', 'bar'],
+    });
+  });
+
+  it('removes wrapping quotes', () => {
+    expect(CosmeticFilter.parse('foo.com##+js(script-name, "a")')?.parseScript()).to.eql({
+      name: 'script-name',
+      args: ['a'],
+    });
+    expect(CosmeticFilter.parse("foo.com##+js(script-name, 'a')")?.parseScript()).to.eql({
+      name: 'script-name',
+      args: ['a'],
     });
   });
 


### PR DESCRIPTION
This is required for scriptlets like:
```
www.youtube.com##+js(rpnt, script, /(\(function serverContract\(\))/, '/*start*/(function(){const e={apply:(e,a,r)=>{if(Array.isArray(r)){const e=r[0];(e.adPlacements||e.adSlots||e.adBreakHeartbeatParams||e.playerResponse)&&(r=[{}])}return Reflect.apply(e,a,r)}};Object.getOwnPropertyNames=new Proxy(Object.getOwnPropertyNames,e);let t=function(){document.querySelectorAll("script").forEach(e=>{e.textContent=e.textContent.replace(/\/\*start\*\/(.*)\/\*end\*\//g,"")})};"loading"!==document.readyState?t():document.addEventListener("DOMContentLoaded",t)}());/*end*/ $1')
```
The last argument is quoted but should be used without the quotes. 

fix https://github.com/ghostery/ghostery-extension/issues/1360