### PR TITLE
Network filter toString fix

### DIFF
--- a/packages/adblocker/src/filters/network.ts
+++ b/packages/adblocker/src/filters/network.ts
@@ -1122,7 +1122,7 @@ export default class NetworkFilter implements IFilter {
       filter += this.getFilter();
     }
 
-    if (this.isRightAnchor()) {
+    if (this.isRightAnchor() && filter[filter.length - 1] !== '^') {
       filter += '|';
     }
 

--- a/packages/adblocker/test/parsing.test.ts
+++ b/packages/adblocker/test/parsing.test.ts
@@ -160,8 +160,9 @@ describe('Network filters', () => {
     });
 
     it('pprint anchored hostnames', () => {
+      checkToString('||foo.com^', '||foo.com^');
       checkToString('@@||foo.com', '@@||foo.com^');
-      checkToString('@@||foo.com|', '@@||foo.com^|');
+      checkToString('@@||foo.com|', '@@||foo.com^');
       checkToString('|foo.com|', '|foo.com|');
       checkToString('foo.com|', 'foo.com|');
     });


### PR DESCRIPTION
I've run into a weird edge case. `NetworkFilter#toString()` adds a right anchor to filters ending with a separator. 
```
  1) Network filters
       toString
         pprint anchored hostnames:

      AssertionError: expected '||foo.com^|' to equal '||foo.com^'
```

This may potentially be correct, but some other part of our toolchain (abp2dnr) does not handle the right anchors and thus ends up with a broken filter (as DNR does not support right anchor either, afaict). 

Anyways, resulting syntax `^|` is extremely rare, I found only one filter using it in both uAssets and Easylist. 

Can we make this change?