### PR TITLE
fix: network filter ending with right hat recognized as regex

### DIFF
--- a/packages/adblocker/src/filters/network.ts
+++ b/packages/adblocker/src/filters/network.ts
@@ -838,7 +838,6 @@ export default class NetworkFilter implements IFilter {
 
       // TODO
       // - ignore hostname anchor is not hostname provided
-
       if (hostname !== undefined) {
         hostname = hostname.toLowerCase();
         if (hasUnicode(hostname)) {
@@ -1540,8 +1539,17 @@ function setNetworkMask(mask: number, m: number, value: boolean): number {
  * regex filter (it contains a '*' or '^' char).
  */
 function checkIsRegex(filter: string, start: number, end: number): boolean {
+  // Check hostname-like format for simple ending hat sign
+  if (
+    filter.charCodeAt(0) !== 47 /* '/' */ &&
+    filter.charCodeAt(end - 1) !== 47 &&
+    filter.charCodeAt(end - 1) === 94 /* '^' */
+  ) {
+    return false;
+  }
+
   const indexOfSeparator = filter.indexOf('^', start);
-  if (indexOfSeparator !== -1 && indexOfSeparator < end - 1) {
+  if (indexOfSeparator !== -1 && indexOfSeparator < end) {
     return true;
   }
 

--- a/packages/adblocker/src/filters/network.ts
+++ b/packages/adblocker/src/filters/network.ts
@@ -1541,7 +1541,7 @@ function setNetworkMask(mask: number, m: number, value: boolean): number {
  */
 function checkIsRegex(filter: string, start: number, end: number): boolean {
   const indexOfSeparator = filter.indexOf('^', start);
-  if (indexOfSeparator !== -1 && indexOfSeparator < end) {
+  if (indexOfSeparator !== -1 && indexOfSeparator < end - 1) {
     return true;
   }
 

--- a/packages/adblocker/src/filters/network.ts
+++ b/packages/adblocker/src/filters/network.ts
@@ -1536,7 +1536,16 @@ function setNetworkMask(mask: number, m: number, value: boolean): number {
 }
 
 function checkIsHostname(filter: string, start: number, end: number): boolean {
-  return parse(filter.slice(start, end)).hostname !== null;
+  const range = filter.slice(start, end);
+
+  return (
+    parse(range, {
+      extractHostname: false,
+    }).hostname ===
+    parse(range, {
+      extractHostname: true,
+    }).hostname
+  );
 }
 
 /**

--- a/packages/adblocker/src/filters/network.ts
+++ b/packages/adblocker/src/filters/network.ts
@@ -775,16 +775,6 @@ export default class NetworkFilter implements IFilter {
         filterIndexEnd -= 1;
       }
 
-      // Remove leading '*' if the filter is not hostname anchored.
-      if (
-        getBit(mask, NETWORK_FILTER_MASK.isHostnameAnchor) === false &&
-        filterIndexEnd - filterIndexStart > 0 &&
-        line.charCodeAt(filterIndexStart) === 42 /* '*' */
-      ) {
-        mask = clearBit(mask, NETWORK_FILTER_MASK.isLeftAnchor);
-        filterIndexStart += 1;
-      }
-
       // Transform filters on protocol (http, https, ws)
       if (getBit(mask, NETWORK_FILTER_MASK.isLeftAnchor)) {
         if (

--- a/packages/adblocker/test/parsing.test.ts
+++ b/packages/adblocker/test/parsing.test.ts
@@ -220,6 +220,12 @@ describe('Network filters', () => {
       filter: 'foo.com/ads',
       isImportant: true,
     });
+
+    network('*bar^', {
+      ...base,
+      filter: 'bar^',
+      hostname: '',
+    });
   });
 
   it('parses ||pattern', () => {
@@ -346,11 +352,6 @@ describe('Network filters', () => {
       isRegex: true,
     };
 
-    network('*bar^', {
-      ...base,
-      filter: '*bar^',
-      hostname: '',
-    });
     network('foo.com/*bar^', {
       ...base,
       filter: 'foo.com/*bar^',

--- a/packages/adblocker/test/parsing.test.ts
+++ b/packages/adblocker/test/parsing.test.ts
@@ -348,7 +348,7 @@ describe('Network filters', () => {
 
     network('*bar^', {
       ...base,
-      filter: 'bar^',
+      filter: '*bar^',
       hostname: '',
     });
     network('foo.com/*bar^', {

--- a/packages/adblocker/test/parsing.test.ts
+++ b/packages/adblocker/test/parsing.test.ts
@@ -170,6 +170,7 @@ describe('Network filters', () => {
       checkToString('@@||foo.com|', '@@||foo.com^');
       checkToString('|foo.com|', '|foo.com|');
       checkToString('foo.com|', 'foo.com|');
+      checkToString('foo.com^', 'foo.com^');
     });
 
     it('pprint domain', () => {


### PR DESCRIPTION
fixes #3694

---

## Summary

This fixes a network filter ending with a hat sign (`hostname^`) not to be resolved as a regexp filter.

### Internals

The `NETWORK_FILTER_MASK.isRegex` is being set at the following point. The `filter` has a legit length then `checkIsRegex` does false positives.

**packages/adblocker/src/filters/network.ts**

```ts
if (filterIndexEnd - filterIndexStart > 0) {
  filter = line.slice(filterIndexStart, filterIndexEnd).toLowerCase();

  mask = setNetworkMask(mask, NETWORK_FILTER_MASK.isUnicode, hasUnicode(filter));
  if (getBit(mask, NETWORK_FILTER_MASK.isRegex) === false) {
    mask = setNetworkMask(
      mask,
      NETWORK_FILTER_MASK.isRegex,
      checkIsRegex(filter, 0, filter.length),
    );
  }
}
```

`checkIsRegex` checks if the `filter` string has a hat sign or asterisk sign. However, this logic also triggers `hostname^` pattern to be checked.

```ts
/**
 * Check if the sub-string contained between the indices start and end is a
 * regex filter (it contains a '*' or '^' char).
 */
function checkIsRegex(filter: string, start: number, end: number): boolean {
  const indexOfSeparator = filter.indexOf('^', start);
  if (indexOfSeparator !== -1 && indexOfSeparator < end) {
    return true;
  }

  const indexOfWildcard = filter.indexOf('*', start);
  return indexOfWildcard !== -1 && indexOfWildcard < end;
}
```

## Suggested changes

I added a proper hostname checker to validate if the `filter` is a valid hostname in the `checkIsRegex` function. The suggested changes check if the `filter` string has a trailing hat because if a hat sign in other locations does present, it does mean it's often used as a regex symbol.

```ts
/**
 * Check if the sub-string contained between the indices start and end is a
 * regex filter (it contains a '*' or '^' char).
 */
function checkIsRegex(filter: string, start: number, end: number): boolean {
  // Check if the filter has a trailing hat without pathes (mostly for hostname) and then trim it
  if (filter.charCodeAt(end - 1) === 94 /* '^' */ && checkIsHostname(filter, start, end - 1)) {
    return false;
  }

  const indexOfSeparator = filter.indexOf('^', start);
  if (indexOfSeparator !== -1 && indexOfSeparator < end) {
    return true;
  }

  const indexOfWildcard = filter.indexOf('*', start);
  return indexOfWildcard !== -1 && indexOfWildcard < end;
}
```

Also some cases including glob pattern need to be judged. For example, `hostname*^` pattern should be handled as regex because it includes glob pattern. Therefore, checking the trailing hat is preferred in this case.