### PR TITLE
Tests: hidden/invisible mode after test

### DIFF
--- a/packages/adblocker/test/data/blns.txt
+++ b/packages/adblocker/test/data/blns.txt
@@ -703,6 +703,8 @@ Roses are [0;31mred[0m, violets are [0;34mblue. Hope you enjoy terminal hue[
 But now...[20Cfor my greatest trick...[8m
 The quick brown fox... [Beeeep]
 
+Disable invisible mode [28m
+
 #	iOS Vulnerabilities
 #
 #	Strings which crashed iMessage in various versions of iOS


### PR DESCRIPTION
Due to escape sequence terminal output was hidden when running tests, this made verifying details of full test run impossible. 

Hidden mode is enabled with `ESC[8m` and disabled with `ESC[28m`