### PR TITLE
Build system: fix yarn warnings for @types/node

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@eslint/js": "^9.3.0",
     "@remusao/auto-config": "^1.1.2",
     "@types/benchmark": "^2.1.3",
-    "@types/node": "^20.6.2",
+    "@types/node": "^20.12.12",
     "auto": "^11.0.5",
     "benchmark": "^2.1.4",
     "chalk": "^5.3.0",

--- a/packages/adblocker-electron-example/package.json
+++ b/packages/adblocker-electron-example/package.json
@@ -66,6 +66,7 @@
     "ts-node": "^10.9.1"
   },
   "devDependencies": {
+    "@types/node": "^20.12.12",
     "eslint": "^9.3.0",
     "typescript": "^5.4.5"
   }

--- a/packages/adblocker-electron/package.json
+++ b/packages/adblocker-electron/package.json
@@ -50,6 +50,7 @@
     "@rollup/plugin-node-resolve": "^15.2.3",
     "@types/chai": "^4.3.6",
     "@types/mocha": "^10.0.1",
+    "@types/node": "^20.12.12",
     "chai": "^5.1.0",
     "electron": "^30.0.0",
     "eslint": "^9.3.0",

--- a/packages/adblocker-playwright-example/package.json
+++ b/packages/adblocker-playwright-example/package.json
@@ -31,6 +31,7 @@
     "ts-node": "^10.9.1"
   },
   "devDependencies": {
+    "@types/node": "^20.12.12",
     "eslint": "^9.3.0",
     "typescript": "^5.4.5"
   },

--- a/packages/adblocker-puppeteer-example/package.json
+++ b/packages/adblocker-puppeteer-example/package.json
@@ -31,6 +31,7 @@
     "ts-node": "^10.9.1"
   },
   "devDependencies": {
+    "@types/node": "^20.12.12",
     "eslint": "^9.3.0",
     "typescript": "^5.4.5"
   },

--- a/packages/adblocker-puppeteer/package.json
+++ b/packages/adblocker-puppeteer/package.json
@@ -49,6 +49,7 @@
     "@rollup/plugin-node-resolve": "^15.2.3",
     "@types/chai": "^4.3.6",
     "@types/mocha": "^10.0.1",
+    "@types/node": "^20.12.12",
     "chai": "^5.1.0",
     "eslint": "^9.3.0",
     "mocha": "^10.2.0",

--- a/packages/adblocker-webextension-cosmetics/package.json
+++ b/packages/adblocker-webextension-cosmetics/package.json
@@ -78,6 +78,7 @@
     "@types/chrome": "^0.0.268",
     "@types/jsdom": "^21.1.3",
     "@types/mocha": "^10.0.1",
+    "@types/node": "^20.12.12",
     "@types/sinon": "^17.0.2",
     "chai": "^5.1.0",
     "eslint": "^9.3.0",

--- a/packages/adblocker-webextension/package.json
+++ b/packages/adblocker-webextension/package.json
@@ -42,6 +42,7 @@
     "@rollup/plugin-typescript": "^11.1.3",
     "@types/chai": "^4.3.6",
     "@types/mocha": "^10.0.1",
+    "@types/node": "^20.12.12",
     "chai": "^5.1.0",
     "eslint": "^9.3.0",
     "mocha": "^10.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -410,6 +410,7 @@ __metadata:
   resolution: "@cliqz/adblocker-electron-example@workspace:packages/adblocker-electron-example"
   dependencies:
     "@cliqz/adblocker-electron": "npm:^1.27.3"
+    "@types/node": "npm:^20.12.12"
     cross-fetch: "npm:^4.0.0"
     electron: "npm:^30.0.0"
     eslint: "npm:^9.3.0"
@@ -447,6 +448,7 @@ __metadata:
     "@rollup/plugin-node-resolve": "npm:^15.2.3"
     "@types/chai": "npm:^4.3.6"
     "@types/mocha": "npm:^10.0.1"
+    "@types/node": "npm:^20.12.12"
     chai: "npm:^5.1.0"
     electron: "npm:^30.0.0"
     eslint: "npm:^9.3.0"
@@ -492,6 +494,7 @@ __metadata:
   resolution: "@cliqz/adblocker-playwright-example@workspace:packages/adblocker-playwright-example"
   dependencies:
     "@cliqz/adblocker-playwright": "npm:^1.27.3"
+    "@types/node": "npm:^20.12.12"
     cross-fetch: "npm:^4.0.0"
     eslint: "npm:^9.3.0"
     playwright: "npm:^1.38.0"
@@ -530,6 +533,7 @@ __metadata:
   resolution: "@cliqz/adblocker-puppeteer-example@workspace:packages/adblocker-puppeteer-example"
   dependencies:
     "@cliqz/adblocker-puppeteer": "npm:^1.27.3"
+    "@types/node": "npm:^20.12.12"
     cross-fetch: "npm:^4.0.0"
     eslint: "npm:^9.3.0"
     puppeteer: "npm:22.10.0"
@@ -547,6 +551,7 @@ __metadata:
     "@rollup/plugin-node-resolve": "npm:^15.2.3"
     "@types/chai": "npm:^4.3.6"
     "@types/mocha": "npm:^10.0.1"
+    "@types/node": "npm:^20.12.12"
     chai: "npm:^5.1.0"
     eslint: "npm:^9.3.0"
     mocha: "npm:^10.2.0"
@@ -576,6 +581,7 @@ __metadata:
     "@types/chrome": "npm:^0.0.268"
     "@types/jsdom": "npm:^21.1.3"
     "@types/mocha": "npm:^10.0.1"
+    "@types/node": "npm:^20.12.12"
     "@types/sinon": "npm:^17.0.2"
     chai: "npm:^5.1.0"
     eslint: "npm:^9.3.0"
@@ -621,6 +627,7 @@ __metadata:
     "@rollup/plugin-typescript": "npm:^11.1.3"
     "@types/chai": "npm:^4.3.6"
     "@types/mocha": "npm:^10.0.1"
+    "@types/node": "npm:^20.12.12"
     chai: "npm:^5.1.0"
     eslint: "npm:^9.3.0"
     mocha: "npm:^10.2.0"
@@ -2167,7 +2174,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:*, @types/node@npm:^20.6.2, @types/node@npm:^20.9.0":
+"@types/node@npm:*, @types/node@npm:^20.12.12, @types/node@npm:^20.6.2, @types/node@npm:^20.9.0":
   version: 20.12.12
   resolution: "@types/node@npm:20.12.12"
   dependencies:
@@ -2422,7 +2429,7 @@ __metadata:
     "@eslint/js": "npm:^9.3.0"
     "@remusao/auto-config": "npm:^1.1.2"
     "@types/benchmark": "npm:^2.1.3"
-    "@types/node": "npm:^20.6.2"
+    "@types/node": "npm:^20.12.12"
     auto: "npm:^11.0.5"
     benchmark: "npm:^2.1.4"
     chalk: "npm:^5.3.0"


### PR DESCRIPTION
`yarn install` was showing such warnings
```
➤ YN0002: │ @cliqz/adblocker-puppeteer-example@workspace:packages/adblocker-puppeteer-example doesn't provide @types/node (p0d389), requested by ts-node.
➤ YN0002: │ @cliqz/adblocker-puppeteer@workspace:packages/adblocker-puppeteer [01506] doesn't provide @types/node (p21284), requested by ts-node.
➤ YN0002: │ @cliqz/adblocker-puppeteer@workspace:packages/adblocker-puppeteer doesn't provide @types/node (pea7c0), requested by ts-node.
➤ YN0002: │ @cliqz/adblocker-webextension-cosmetics@workspace:packages/adblocker-webextension-cosmetics doesn't provide @types/node (pdb198), requested by ts-node.
➤ YN0002: │ @cliqz/adblocker-webextension@workspace:packages/adblocker-webextension doesn't provide @types/node (p6be02), requested by ts-node.
```
remedy was to add `@types/node` as dev dependency to listed packages. 