### PR TITLE
Fix engine updates

### DIFF
--- a/packages/adblocker/test/engine/engine.test.ts
+++ b/packages/adblocker/test/engine/engine.test.ts
@@ -1400,4 +1400,15 @@ describe('diff updates', () => {
 
   testUpdates('empty engine', []);
   testUpdates('easylist engine', loadEasyListFilters());
+
+  it.only('updates without duplicates', () => {
+    const filters = ['youtube.com##+js(test)', '||bar.com^'];
+    const engine = new Engine();
+    engine.updateFromDiff({ added: filters });
+    expect(engine.cosmetics.getFilters()).to.have.length(1);
+    expect(engine.filters.getFilters()).to.have.length(1);
+    engine.updateFromDiff({ added: filters });
+    expect(engine.cosmetics.getFilters()).to.have.length(1);
+    expect(engine.filters.getFilters()).to.have.length(1);
+  });
 });

--- a/packages/adblocker/test/preprocessor.test.ts
+++ b/packages/adblocker/test/preprocessor.test.ts
@@ -238,4 +238,19 @@ describe('preprocessors', () => {
 !#endif`,
     );
   });
+
+  it.only('updates engine correcly', () => {
+    const filters = `
+      youtube.com##+js(test)
+      ||bar.com^
+    `;
+    const engine = new FilterEngine({ config: { loadPreprocessors: true } });
+    const diff = generateDiff('', filters, engine.config);
+    engine.updateFromDiff(diff, env);
+    expect(engine.cosmetics.getFilters()).to.have.length(1);
+    expect(engine.filters.getFilters()).to.have.length(1);
+    engine.updateFromDiff(diff, env);
+    expect(engine.cosmetics.getFilters()).to.have.length(1);
+    expect(engine.filters.getFilters()).to.have.length(1);
+  });
 });

--- a/packages/adblocker/test/preprocessor.test.ts
+++ b/packages/adblocker/test/preprocessor.test.ts
@@ -238,19 +238,4 @@ describe('preprocessors', () => {
 !#endif`,
     );
   });
-
-  it.only('updates engine correcly', () => {
-    const filters = `
-      youtube.com##+js(test)
-      ||bar.com^
-    `;
-    const engine = new FilterEngine({ config: { loadPreprocessors: true } });
-    const diff = generateDiff('', filters, engine.config);
-    engine.updateFromDiff(diff, env);
-    expect(engine.cosmetics.getFilters()).to.have.length(1);
-    expect(engine.filters.getFilters()).to.have.length(1);
-    engine.updateFromDiff(diff, env);
-    expect(engine.cosmetics.getFilters()).to.have.length(1);
-    expect(engine.filters.getFilters()).to.have.length(1);
-  });
 });

--- a/packages/adblocker/test/reverse-index.test.ts
+++ b/packages/adblocker/test/reverse-index.test.ts
@@ -111,7 +111,7 @@ describe('ReverseIndex', () => {
 
         for (const optimize of [noopOptimizeNetwork, optimizeNetwork]) {
           describe(`optimize = ${optimize !== noopOptimizeNetwork}`, () => {
-            it('#update', () => {
+            it.only('#update', () => {
               const reverseIndex = new ReverseIndex({
                 config,
                 deserialize: NetworkFilter.deserialize,
@@ -125,6 +125,15 @@ describe('ReverseIndex', () => {
               expect(filters.map((f) => f.rawLine)).to.eql(['||foo.com']);
 
               // Add one new filter
+              reverseIndex.update(
+                parseFilters('||bar.com', { loadCosmeticFilters: false, debug: true })
+                  .networkFilters,
+                undefined,
+              );
+              filters = reverseIndex.getFilters();
+              expect(filters.map((f) => f.rawLine)).to.eql(['||foo.com', '||bar.com']);
+
+              // Add same filter
               reverseIndex.update(
                 parseFilters('||bar.com', { loadCosmeticFilters: false, debug: true })
                   .networkFilters,


### PR DESCRIPTION
`updateFromDiff` duplicates filters in the buckets. It is confirm it leads to double matching and likely to memory leaks. 