### PR TITLE
fix: filters being duplicated by preprocessors

### DIFF
--- a/packages/adblocker/src/engine/engine.ts
+++ b/packages/adblocker/src/engine/engine.ts
@@ -641,9 +641,6 @@ export default class FilterEngine extends EventEmitter<
               .concat(networkFilters.map((filter) => filter.getId())),
           );
 
-          Array.prototype.push.apply(removedCosmeticFilters, cosmeticFilters);
-          Array.prototype.push.apply(removedNetworkFilters, networkFilters);
-
           removedPreprocessors.push(
             new Preprocessor({
               condition,
@@ -662,9 +659,6 @@ export default class FilterEngine extends EventEmitter<
               .concat(cosmeticFilters.map((filter) => filter.getId()))
               .concat(networkFilters.map((filter) => filter.getId())),
           );
-
-          Array.prototype.push.apply(newCosmeticFilters, cosmeticFilters);
-          Array.prototype.push.apply(newNetworkFilters, networkFilters);
 
           newPreprocessors.push(
             new Preprocessor({

--- a/packages/adblocker/src/lists.ts
+++ b/packages/adblocker/src/lists.ts
@@ -442,6 +442,11 @@ export function generateDiff(
   return {
     added: Array.from(added),
     removed: Array.from(removed),
+    // For the filters under `preprocessors` property, it doesn't mean those are "filters".
+    // Those are "a list of filters affected by preprocessors" not the "filters" itself.
+    // Therefore, they shouldn't be treated as filters.
+    // Instead, we put "filters" in `added` and `removed` properties.
+    // This provides backward-compatibility and simplicity.
     preprocessors,
   };
 }

--- a/packages/adblocker/test/lists.test.ts
+++ b/packages/adblocker/test/lists.test.ts
@@ -244,6 +244,44 @@ bar.baz
         },
       },
     });
+
+    expect(
+      generateDiff(
+        `||foo.com^`,
+        `!#if true
+||foo.com^
+!#endif`,
+        config,
+      ),
+    ).to.eql({
+      added: [],
+      removed: [],
+      preprocessors: {
+        true: {
+          added: ['||foo.com^'],
+          removed: [],
+        },
+      },
+    });
+
+    expect(
+      generateDiff(
+        `!#if true
+||foo.com^
+!#endif`,
+        `||foo.com^`,
+        config,
+      ),
+    ).to.eql({
+      added: [],
+      removed: [],
+      preprocessors: {
+        true: {
+          added: [],
+          removed: ['||foo.com^'],
+        },
+      },
+    });
   });
 });
 

--- a/packages/adblocker/test/preprocessor.test.ts
+++ b/packages/adblocker/test/preprocessor.test.ts
@@ -239,3 +239,31 @@ describe('preprocessors', () => {
     );
   });
 });
+
+describe('updating', () => {
+  it('correctly distinguishes filters and filters with conditions', () => {
+    const engine = FilterEngine.parse(`||foo.com^`, {
+      loadPreprocessors: true,
+    });
+
+    engine.updateFromDiff({
+      preprocessors: {
+        true: {
+          added: ['||foo.com^'],
+        },
+      },
+    });
+
+    expect(engine.getFilters().networkFilters.length).to.be.eql(1);
+
+    engine.updateFromDiff({
+      preprocessors: {
+        true: {
+          removed: ['||foo.com^'],
+        },
+      },
+    });
+
+    expect(engine.getFilters().networkFilters.length).to.be.eql(1);
+  });
+});

--- a/packages/adblocker/test/preprocessor.test.ts
+++ b/packages/adblocker/test/preprocessor.test.ts
@@ -265,5 +265,17 @@ describe('updating', () => {
     });
 
     expect(engine.getFilters().networkFilters.length).to.be.eql(1);
+
+    const youtubeFilter = 'youtube.com##+js(test)';
+    engine.updateFromDiff({
+      added: [youtubeFilter],
+      preprocessors: {
+        true: {
+          added: [youtubeFilter],
+        },
+      },
+    });
+
+    expect(engine.cosmetics.getFilters()).to.have.length(1);
   });
 });


### PR DESCRIPTION
This PR solves the problem that created duplicated entries in the filters engine. The problem was found as scriptlets injected multiple times (more than intended) on YouTube. After then, the fact that those filters had preprocessors revealed. The problem was in `updateFromDiff` function that pushes preprocessor filters to normal filters diff. The mental model and understanding to the diff object was not clear, so this problem happened.

To prevent similar issues in future, tests and comments are added.