### PR TITLE
Update typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "lerna": "^8.0.0",
     "patch-package": "^8.0.0",
     "prettier": "^3.0.3",
-    "typescript": "^5.4.5",
+    "typescript": "^5.5.2",
     "typescript-eslint": "8.0.0-alpha.34"
   },
   "auto": {

--- a/packages/adblocker-content/package.json
+++ b/packages/adblocker-content/package.json
@@ -47,7 +47,7 @@
     "eslint": "^9.3.0",
     "rimraf": "^5.0.1",
     "rollup": "^4.0.2",
-    "typescript": "^5.4.5"
+    "typescript": "^5.5.2"
   },
   "contributors": [
     {

--- a/packages/adblocker-electron-example/package.json
+++ b/packages/adblocker-electron-example/package.json
@@ -68,6 +68,6 @@
   "devDependencies": {
     "@types/node": "^20.12.12",
     "eslint": "^9.3.0",
-    "typescript": "^5.4.5"
+    "typescript": "^5.5.2"
   }
 }

--- a/packages/adblocker-electron-preload/package.json
+++ b/packages/adblocker-electron-preload/package.json
@@ -51,7 +51,7 @@
     "eslint": "^9.3.0",
     "rimraf": "^5.0.1",
     "rollup": "^4.0.2",
-    "typescript": "^5.4.5"
+    "typescript": "^5.5.2"
   },
   "contributors": [
     {

--- a/packages/adblocker-electron/package.json
+++ b/packages/adblocker-electron/package.json
@@ -59,7 +59,7 @@
     "rimraf": "^5.0.1",
     "rollup": "^4.17.2",
     "ts-node": "^10.9.1",
-    "typescript": "^5.4.5"
+    "typescript": "^5.5.2"
   },
   "contributors": [
     {

--- a/packages/adblocker-extended-selectors/package.json
+++ b/packages/adblocker-extended-selectors/package.json
@@ -52,7 +52,7 @@
     "rimraf": "^5.0.1",
     "rollup": "^4.17.2",
     "ts-node": "^10.9.1",
-    "typescript": "^5.4.5"
+    "typescript": "^5.5.2"
   },
   "contributors": [
     {

--- a/packages/adblocker-playwright-example/package.json
+++ b/packages/adblocker-playwright-example/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "@types/node": "^20.12.12",
     "eslint": "^9.3.0",
-    "typescript": "^5.4.5"
+    "typescript": "^5.5.2"
   },
   "contributors": [
     {

--- a/packages/adblocker-playwright/package.json
+++ b/packages/adblocker-playwright/package.json
@@ -57,7 +57,7 @@
     "playwright": "^1.38.0",
     "rimraf": "^5.0.1",
     "rollup": "^4.17.2",
-    "typescript": "^5.4.5"
+    "typescript": "^5.5.2"
   },
   "contributors": [
     {

--- a/packages/adblocker-puppeteer-example/package.json
+++ b/packages/adblocker-puppeteer-example/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "@types/node": "^20.12.12",
     "eslint": "^9.3.0",
-    "typescript": "^5.4.5"
+    "typescript": "^5.5.2"
   },
   "contributors": [
     {

--- a/packages/adblocker-puppeteer/package.json
+++ b/packages/adblocker-puppeteer/package.json
@@ -59,7 +59,7 @@
     "rimraf": "^5.0.1",
     "rollup": "^4.17.2",
     "ts-node": "^10.9.1",
-    "typescript": "^5.4.5"
+    "typescript": "^5.5.2"
   },
   "contributors": [
     {

--- a/packages/adblocker-webextension-cosmetics/package.json
+++ b/packages/adblocker-webextension-cosmetics/package.json
@@ -89,7 +89,7 @@
     "rollup": "^4.0.2",
     "sinon": "^18.0.0",
     "ts-node": "^10.9.1",
-    "typescript": "^5.4.5"
+    "typescript": "^5.5.2"
   },
   "dependencies": {
     "@cliqz/adblocker-content": "^1.27.11",

--- a/packages/adblocker-webextension-example/package.json
+++ b/packages/adblocker-webextension-example/package.json
@@ -42,7 +42,7 @@
     "eslint": "^9.3.0",
     "rimraf": "^5.0.1",
     "rollup": "^4.0.2",
-    "typescript": "^5.4.5"
+    "typescript": "^5.5.2"
   },
   "contributors": [
     {

--- a/packages/adblocker-webextension/package.json
+++ b/packages/adblocker-webextension/package.json
@@ -50,7 +50,7 @@
     "rimraf": "^5.0.1",
     "rollup": "^4.0.2",
     "ts-node": "^10.9.1",
-    "typescript": "^5.4.5"
+    "typescript": "^5.5.2"
   },
   "dependencies": {
     "@cliqz/adblocker": "^1.27.11",

--- a/packages/adblocker/package.json
+++ b/packages/adblocker/package.json
@@ -99,7 +99,7 @@
     "rimraf": "^5.0.1",
     "rollup": "^4.0.2",
     "ts-node": "^10.9.1",
-    "typescript": "^5.4.5"
+    "typescript": "^5.5.2"
   },
   "dependencies": {
     "@cliqz/adblocker-content": "^1.27.11",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
-    "target": "es2017",
+    "target": "es2018",
     "module": "preserve",
     "moduleResolution": "Bundler",
     "strict": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -384,7 +384,7 @@ __metadata:
     eslint: "npm:^9.3.0"
     rimraf: "npm:^5.0.1"
     rollup: "npm:^4.0.2"
-    typescript: "npm:^5.4.5"
+    typescript: "npm:^5.5.2"
   languageName: unknown
   linkType: soft
 
@@ -398,7 +398,7 @@ __metadata:
     electron: "npm:^31.0.0"
     eslint: "npm:^9.3.0"
     ts-node: "npm:^10.9.1"
-    typescript: "npm:^5.4.5"
+    typescript: "npm:^5.5.2"
   languageName: unknown
   linkType: soft
 
@@ -415,7 +415,7 @@ __metadata:
     eslint: "npm:^9.3.0"
     rimraf: "npm:^5.0.1"
     rollup: "npm:^4.0.2"
-    typescript: "npm:^5.4.5"
+    typescript: "npm:^5.5.2"
   peerDependencies:
     electron: ">11"
   languageName: unknown
@@ -441,7 +441,7 @@ __metadata:
     rollup: "npm:^4.17.2"
     tldts-experimental: "npm:^6.0.14"
     ts-node: "npm:^10.9.1"
-    typescript: "npm:^5.4.5"
+    typescript: "npm:^5.5.2"
   peerDependencies:
     electron: ">11"
   languageName: unknown
@@ -465,7 +465,7 @@ __metadata:
     rimraf: "npm:^5.0.1"
     rollup: "npm:^4.17.2"
     ts-node: "npm:^10.9.1"
-    typescript: "npm:^5.4.5"
+    typescript: "npm:^5.5.2"
   languageName: unknown
   linkType: soft
 
@@ -479,7 +479,7 @@ __metadata:
     eslint: "npm:^9.3.0"
     playwright: "npm:^1.38.0"
     ts-node: "npm:^10.9.1"
-    typescript: "npm:^5.4.5"
+    typescript: "npm:^5.5.2"
   languageName: unknown
   linkType: soft
 
@@ -501,7 +501,7 @@ __metadata:
     rimraf: "npm:^5.0.1"
     rollup: "npm:^4.17.2"
     tldts-experimental: "npm:^6.0.14"
-    typescript: "npm:^5.4.5"
+    typescript: "npm:^5.5.2"
   peerDependencies:
     playwright: ^1.x
   languageName: unknown
@@ -517,7 +517,7 @@ __metadata:
     eslint: "npm:^9.3.0"
     puppeteer: "npm:22.12.1"
     ts-node: "npm:^10.9.1"
-    typescript: "npm:^5.4.5"
+    typescript: "npm:^5.5.2"
   languageName: unknown
   linkType: soft
 
@@ -541,7 +541,7 @@ __metadata:
     rollup: "npm:^4.17.2"
     tldts-experimental: "npm:^6.0.14"
     ts-node: "npm:^10.9.1"
-    typescript: "npm:^5.4.5"
+    typescript: "npm:^5.5.2"
   peerDependencies:
     puppeteer: ">5"
   languageName: unknown
@@ -570,7 +570,7 @@ __metadata:
     rollup: "npm:^4.0.2"
     sinon: "npm:^18.0.0"
     ts-node: "npm:^10.9.1"
-    typescript: "npm:^5.4.5"
+    typescript: "npm:^5.5.2"
   languageName: unknown
   linkType: soft
 
@@ -587,7 +587,7 @@ __metadata:
     eslint: "npm:^9.3.0"
     rimraf: "npm:^5.0.1"
     rollup: "npm:^4.0.2"
-    typescript: "npm:^5.4.5"
+    typescript: "npm:^5.5.2"
     webextension-polyfill-ts: "npm:^0.26.0"
   languageName: unknown
   linkType: soft
@@ -611,7 +611,7 @@ __metadata:
     rollup: "npm:^4.0.2"
     tldts-experimental: "npm:^6.0.14"
     ts-node: "npm:^10.9.1"
-    typescript: "npm:^5.4.5"
+    typescript: "npm:^5.5.2"
     webextension-polyfill-ts: "npm:^0.26.0"
   languageName: unknown
   linkType: soft
@@ -644,7 +644,7 @@ __metadata:
     rollup: "npm:^4.0.2"
     tldts-experimental: "npm:^6.0.14"
     ts-node: "npm:^10.9.1"
-    typescript: "npm:^5.4.5"
+    typescript: "npm:^5.5.2"
   languageName: unknown
   linkType: soft
 
@@ -2486,7 +2486,7 @@ __metadata:
     lerna: "npm:^8.0.0"
     patch-package: "npm:^8.0.0"
     prettier: "npm:^3.0.3"
-    typescript: "npm:^5.4.5"
+    typescript: "npm:^5.5.2"
     typescript-eslint: "npm:8.0.0-alpha.34"
   languageName: unknown
   linkType: soft
@@ -9842,7 +9842,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:>=3 < 6, typescript@npm:^5.4.5":
+"typescript@npm:>=3 < 6":
   version: 5.4.5
   resolution: "typescript@npm:5.4.5"
   bin:
@@ -9852,13 +9852,33 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A>=3 < 6#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.4.5#optional!builtin<compat/typescript>":
+"typescript@npm:^5.5.2":
+  version: 5.5.2
+  resolution: "typescript@npm:5.5.2"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 10/9118b20f248e76b0dbff8737fef65dfa89d02668d4e633d2c5ceac99033a0ca5e8a1c1a53bc94da68e8f67677a88f318663dde859c9e9a09c1e116415daec2ba
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@npm%3A>=3 < 6#optional!builtin<compat/typescript>":
   version: 5.4.5
   resolution: "typescript@patch:typescript@npm%3A5.4.5#optional!builtin<compat/typescript>::version=5.4.5&hash=5adc0c"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 10/760f7d92fb383dbf7dee2443bf902f4365db2117f96f875cf809167f6103d55064de973db9f78fe8f31ec08fff52b2c969aee0d310939c0a3798ec75d0bca2e1
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@npm%3A^5.5.2#optional!builtin<compat/typescript>":
+  version: 5.5.2
+  resolution: "typescript@patch:typescript@npm%3A5.5.2#optional!builtin<compat/typescript>::version=5.5.2&hash=b45daf"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 10/28b3de2ddaf63a7620e7ddbe5d377af71ce93ecc558c41bf0e3d88661d8e6e7aa6c7739164fef98055f69819e41faca49252938ef3633a3dff2734cca6a9042e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Replaces https://github.com/ghostery/adblocker/pull/4035

Typescript 5.5, alarms that regexp named groups are supported from ES2018, which may mean we were breaking on those ES2017 platforms we were targeting. 