### PR TITLE
Cosmetic injection: limit amount of events from mutation observer

### DIFF
--- a/packages/adblocker-content/adblocker.ts
+++ b/packages/adblocker-content/adblocker.ts
@@ -41,15 +41,9 @@ function getElementsFromMutations(mutations: MutationRecord[]): Element[] {
   const elements: Element[] = [];
 
   for (const mutation of mutations) {
-    if (mutation.type === 'attributes') {
-      if (isElement(mutation.target)) {
-        elements.push(mutation.target);
-      }
-    } else if (mutation.type === 'childList') {
-      for (const addedNode of mutation.addedNodes) {
-        if (isElement(addedNode) && addedNode.id !== SCRIPT_ID) {
-          elements.push(addedNode);
-        }
+    for (const addedNode of mutation.addedNodes) {
+      if (isElement(addedNode) && addedNode.id !== SCRIPT_ID) {
+        elements.push(addedNode);
       }
     }
   }
@@ -151,9 +145,6 @@ export class DOMMonitor {
       });
 
       this.observer.observe(window.document.documentElement, {
-        // Monitor some attributes
-        attributes: true,
-        attributeFilter: ['class', 'id', 'href'],
         childList: true,
         subtree: true,
       });

--- a/packages/adblocker-webextension-cosmetics/test/adblocker.test.ts
+++ b/packages/adblocker-webextension-cosmetics/test/adblocker.test.ts
@@ -123,23 +123,8 @@ describe('#injectCosmetics', () => {
       lifecycle: 'dom-update',
     });
 
-    // Mutate the DOM = change existing nodes
-    div.classList.add('class3');
-    span.classList.add('class4');
-    a.href = 'https://baz.com/';
-    a.classList.add('class1');
 
-    await tick();
     dom.window.close();
-
-    expect(getCosmeticsFilters.callCount).to.eql(4);
-    sinon.assert.calledWith(getCosmeticsFilters.getCall(3), {
-      type: 'features',
-      classes: ['class3', 'class4'],
-      hrefs: ['https://baz.com/'],
-      ids: [],
-      lifecycle: 'dom-update',
-    });
   });
 
   it('injects scriptlet', async () => {


### PR DESCRIPTION
On heavily dynamic pages like https://efa.mvv-muenchen.de/index.html?name_origin=91000680&name_destination=streetID%3A1500000160%3A1%3A9179123%3A-1%3AM%C3%BCnchener%20Stra%C3%9Fe%3AGermering%3AM%C3%BCnchener%20Stra%C3%9Fe%3A%3AM%C3%BCnchener%20Stra%C3%9Fe%3A82110%3AANY%3ADIVA_SINGLEHOUSE%3A1266161%3A5870224%3AMRCV%3ABAY&itdDate=20240704&itdTime=1001&language=de&itdTripDateTimeDepArr=dep#trip@origdest
the adblocker library runs into performance issues, which can comply block website rendering for a period of time. The performance problems comes from MutationObserver spamming too many events. 
This change disabled MutationEvents for modified attributes (ids, hrefs and classes). This is something that uBO is doing for over [7years](https://github.com/gorhill/uBlock/blame/a3576ea6519dc08e5244dafc296dc8ac31b07655/src/js/contentscript.js#L397), so the change should be safe.