### PR TITLE
Optimise DOM mutation handling in `DOMMonitor`

### DIFF
--- a/packages/adblocker-content/adblocker.ts
+++ b/packages/adblocker-content/adblocker.ts
@@ -167,21 +167,22 @@ export class DOMMonitor {
       // This variable needs to be kept outside of mutation observer callback
       // because the role of this array is to keep and accumulate the elements
       // to be passed as an argument before debouncing completes its lifecycle.
-      let updatedNodes: Element[] = [];
+      const nodes: Set<Element> = new Set();
 
       const debouncedHandleUpdatedNodes = debounce(() => {
-        // Keep the reference to the object
-        const updatedNodesInSession = updatedNodes;
+        const nodesRef = Array.from(nodes);
 
         // Initialise and assign new object instead of modifying the existing one.
         // Modifying the existing one will impact to the function running after this onComplete callback.
-        updatedNodes = [];
+        nodes.clear();
 
-        this.handleUpdatedNodes(updatedNodesInSession);
+        this.handleUpdatedNodes(nodesRef);
       }, 25);
 
       this.observer = new window.MutationObserver((mutations: MutationRecord[]) => {
-        updatedNodes.push(...getElementsFromMutations(mutations));
+        for (const element of getElementsFromMutations(mutations)) {
+          nodes.add(element);
+        }
 
         debouncedHandleUpdatedNodes();
       });

--- a/packages/adblocker-content/adblocker.ts
+++ b/packages/adblocker-content/adblocker.ts
@@ -99,8 +99,6 @@ export function extractFeaturesFromDOM(roots: Element[]): {
       if (processedElements.has(element)) {
         continue;
       }
-
-      // Add this element to the processed list.
       processedElements.add(element);
 
       // Any conditions to filter this element out should be placed under this line:

--- a/packages/adblocker-content/adblocker.ts
+++ b/packages/adblocker-content/adblocker.ts
@@ -86,7 +86,7 @@ export function extractFeaturesFromDOM(roots: Element[]): {
   const hrefs: Set<string> = new Set();
   const ids: Set<string> = new Set();
   // Try to reduce duplicate entries by using Set instead of an array.
-  const processedElements: Set<Element> = new Set();
+  const seenElements: Set<Element> = new Set();
 
   for (const root of roots) {
     for (const element of [
@@ -96,17 +96,16 @@ export function extractFeaturesFromDOM(roots: Element[]): {
       ),
     ]) {
       // Check if this object belongs to processedElements and skip if we already did the job on this object.
-      if (processedElements.has(element)) {
+      if (seenElements.has(element)) {
         continue;
       }
-      processedElements.add(element);
+      seenElements.add(element);
 
       // Any conditions to filter this element out should be placed under this line:
       if (ignoredTags.has(element.nodeName.toLowerCase())) {
         continue;
       }
 
-      // Extract features from this element:
       // Update ids
       const id = element.id;
       if (id) {

--- a/packages/adblocker-content/adblocker.ts
+++ b/packages/adblocker-content/adblocker.ts
@@ -87,6 +87,9 @@ export function extractFeaturesFromDOM(roots: Element[]): {
 } {
   // NOTE: This cannot be global as puppeteer needs to be able to serialize this function.
   const ignoredTags = new Set(['br', 'head', 'link', 'meta', 'script', 'style', 's']);
+  const classes: Set<string> = new Set();
+  const hrefs: Set<string> = new Set();
+  const ids: Set<string> = new Set();
   // Try to reduce duplicate entries by using Set instead of an array.
   const elements: Set<Element> = new Set();
 
@@ -104,23 +107,18 @@ export function extractFeaturesFromDOM(roots: Element[]): {
     }
   }
 
-  const classes: Set<string> = new Set();
-  const hrefs: Set<string> = new Set();
-  const ids: Set<string> = new Set();
-
   for (const element of elements) {
     if (element.id) {
       ids.add(element.id);
     }
 
-    if (element.classList) {
-      for (const classEntry of element.classList) {
-        classes.add(classEntry);
-      }
+    for (const classEntry of element.classList) {
+      classes.add(classEntry);
     }
 
-    if (element.hasAttribute('href')) {
-      hrefs.add(element.getAttribute('href')!);
+    const href = element.getAttribute('href');
+    if (typeof href === 'string') {
+      hrefs.add(href);
     }
   }
 

--- a/packages/adblocker-content/adblocker.ts
+++ b/packages/adblocker-content/adblocker.ts
@@ -85,7 +85,6 @@ export function extractFeaturesFromDOM(roots: Element[]): {
   const classes: Set<string> = new Set();
   const hrefs: Set<string> = new Set();
   const ids: Set<string> = new Set();
-  // Try to reduce duplicate entries by using Set instead of an array.
   const seenElements: Set<Element> = new Set();
 
   for (const root of roots) {
@@ -95,7 +94,7 @@ export function extractFeaturesFromDOM(roots: Element[]): {
         '[id]:not(html):not(body),[class]:not(html):not(body),[href]:not(html):not(body)',
       ),
     ]) {
-      // Check if this object belongs to processedElements and skip if we already did the job on this object.
+      // Check if this object belongs to seenElements and skip if we already did the job on this object.
       if (seenElements.has(element)) {
         continue;
       }
@@ -168,13 +167,8 @@ export class DOMMonitor {
       const nodes: Set<Element> = new Set();
 
       const debouncedHandleUpdatedNodes = debounce(() => {
-        const nodesRef = Array.from(nodes);
-
-        // Initialise and assign new object instead of modifying the existing one.
-        // Modifying the existing one will impact to the function running after this onComplete callback.
+        this.handleUpdatedNodes(Array.from(nodes));
         nodes.clear();
-
-        this.handleUpdatedNodes(nodesRef);
       }, 25);
 
       this.observer = new window.MutationObserver((mutations: MutationRecord[]) => {

--- a/packages/adblocker-content/adblocker.ts
+++ b/packages/adblocker-content/adblocker.ts
@@ -166,10 +166,6 @@ export class DOMMonitor {
     window: Pick<Window, 'document'> & { MutationObserver?: typeof MutationObserver },
   ): void {
     if (this.observer === null && window.MutationObserver !== undefined) {
-      // An array of updated nodes in this timespan (or debounce session).
-      // This variable needs to be kept outside of mutation observer callback
-      // because the role of this array is to keep and accumulate the elements
-      // to be passed as an argument before debouncing completes its lifecycle.
       const nodes: Set<Element> = new Set();
 
       const debouncedHandleUpdatedNodes = debounce(() => {

--- a/packages/adblocker-content/adblocker.ts
+++ b/packages/adblocker-content/adblocker.ts
@@ -183,9 +183,7 @@ export class DOMMonitor {
       }, 25);
 
       this.observer = new window.MutationObserver((mutations: MutationRecord[]) => {
-        for (const element of getElementsFromMutations(mutations)) {
-          nodes.add(element);
-        }
+        getElementsFromMutations(mutations).forEach(nodes.add, nodes);
 
         debouncedHandleUpdatedNodes();
       });

--- a/packages/adblocker-content/adblocker.ts
+++ b/packages/adblocker-content/adblocker.ts
@@ -110,12 +110,14 @@ export function extractFeaturesFromDOM(roots: Element[]): {
 
       // Extract features from this element:
       // Update ids
-      if (element.id) {
-        ids.add(element.id);
+      const id = element.id;
+      if (id) {
+        ids.add(id);
       }
 
       // Update classes
-      for (const classEntry of element.classList) {
+      const classList = element.classList;
+      for (const classEntry of classList) {
         classes.add(classEntry);
       }
 

--- a/packages/adblocker-content/adblocker.ts
+++ b/packages/adblocker-content/adblocker.ts
@@ -41,15 +41,15 @@ function debounce(
     maxWait: number;
   },
 ) {
-  let delayedTimer: NodeJS.Timeout | -1 = -1;
-  let maxWaitTimer: NodeJS.Timeout | -1 = -1;
+  let delayedTimer: NodeJS.Timeout | undefined;
+  let maxWaitTimer: NodeJS.Timeout | undefined;
 
   const clear = () => {
     clearTimeout(delayedTimer);
     clearTimeout(maxWaitTimer);
 
-    delayedTimer = -1;
-    maxWaitTimer = -1;
+    delayedTimer = undefined;
+    maxWaitTimer = undefined;
   };
 
   const run = () => {
@@ -59,7 +59,7 @@ function debounce(
 
   return [
     () => {
-      if (maxWait > 0 && maxWaitTimer === -1) {
+      if (maxWait > 0 && maxWaitTimer === undefined) {
         maxWaitTimer = setTimeout(run, maxWait);
       }
 

--- a/packages/adblocker-content/adblocker.ts
+++ b/packages/adblocker-content/adblocker.ts
@@ -33,7 +33,7 @@ export interface IMessageFromBackground {
 
 function debounce<F extends (...args: any[]) => any>(
   fn: F,
-  onComplete: Function,
+  onComplete: (...args: any[]) => any,
   waitFor: number,
 ) {
   let timeout: NodeJS.Timeout;

--- a/packages/adblocker-content/adblocker.ts
+++ b/packages/adblocker-content/adblocker.ts
@@ -94,7 +94,7 @@ export function extractFeaturesFromDOM(roots: Element[]): {
         '[id]:not(html):not(body),[class]:not(html):not(body),[href]:not(html):not(body)',
       ),
     ]) {
-      // Check if this object belongs to seenElements and skip if we already did the job on this object.
+      // If one of root belongs to another root which is parent node of the one, querySelectorAll can return duplicates.
       if (seenElements.has(element)) {
         continue;
       }

--- a/packages/adblocker-content/adblocker.ts
+++ b/packages/adblocker-content/adblocker.ts
@@ -108,15 +108,18 @@ export function extractFeaturesFromDOM(roots: Element[]): {
         continue;
       }
 
-      // Extract features from this element.
+      // Extract features from this element:
+      // Update ids
       if (element.id) {
         ids.add(element.id);
       }
 
+      // Update classes
       for (const classEntry of element.classList) {
         classes.add(classEntry);
       }
 
+      // Update href
       const href = element.getAttribute('href');
       if (typeof href === 'string') {
         hrefs.add(href);

--- a/packages/adblocker-webextension-cosmetics/test/adblocker.test.ts
+++ b/packages/adblocker-webextension-cosmetics/test/adblocker.test.ts
@@ -112,7 +112,7 @@ describe('#injectCosmetics', () => {
     div.appendChild(a);
 
     document.body.appendChild(div);
-    await tick();
+    await tick(30);
 
     sinon.assert.calledThrice(getCosmeticsFilters);
     sinon.assert.calledWith(getCosmeticsFilters.thirdCall, {
@@ -129,7 +129,7 @@ describe('#injectCosmetics', () => {
     a.href = 'https://baz.com/';
     a.classList.add('class1');
 
-    await tick();
+    await tick(30);
     dom.window.close();
 
     expect(getCosmeticsFilters.callCount).to.eql(4);


### PR DESCRIPTION
This PR optimises the mutation handling in `DOMMonitor` by reducing duplicates of targeted elements. Also, it changes adblocker not to block the main event loop of the browser by debouncing the feature extraction task with `setTimeout`.

refs https://efa.mvv-muenchen.de/index.html?name_origin=91000680&name_destination=streetID%[…]20240704&itdTime=1001&language=de&itdTripDateTimeDepArr=dep
refs https://github.com/ghostery/broken-page-reports/issues/732