### PR TITLE
Export typescript types

### DIFF
--- a/packages/adblocker-extended-selectors/adblocker.ts
+++ b/packages/adblocker-extended-selectors/adblocker.ts
@@ -6,13 +6,13 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-export { parse, tokenize } from './src/parse';
-export { querySelectorAll, matches } from './src/eval';
-export * from './src/types';
+export { parse, tokenize } from './src/parse.js';
+export { querySelectorAll, matches } from './src/eval.js';
+export * from './src/types.js';
 export {
   EXTENDED_PSEUDO_CLASSES,
   PSEUDO_CLASSES,
   PSEUDO_ELEMENTS,
   SelectorType,
   classifySelector,
-} from './src/extended';
+} from './src/extended.js';

--- a/packages/adblocker-extended-selectors/package.json
+++ b/packages/adblocker-extended-selectors/package.json
@@ -9,13 +9,13 @@
   "license": "MPL-2.0",
   "type": "module",
   "exports": {
-    "require": "./dist/cjs/adblocker.cjs",
-    "import": "./dist/esm/adblocker.js",
-    "types": "./dist/types/adblocker.d.ts"
+    ".": {
+      "require": "./dist/cjs/adblocker.cjs",
+      "import": "./dist/esm/adblocker.js"
+    }
   },
-  "main": "dist/cjs/adblocker.cjs",
-  "module": "dist/esm/adblocker.js",
-  "types": "dist/types/adblocker.d.ts",
+  "main": "dist/cjs/adblocker.js",
+  "types": "dist/cjs/adblocker.d.ts",
   "files": [
     "LICENSE",
     "dist"
@@ -31,7 +31,10 @@
   "scripts": {
     "clean": "rimraf dist coverage",
     "lint": "eslint src adblocker.ts",
-    "build": "tsc --build ./tsconfig.json && rollup --config ./rollup.config.ts --configPlugin typescript",
+    "build:esm": "tsc --build ./tsconfig.json && echo \"{ \\\"type\\\": \\\"module\\\" }\" > dist/esm/package.json",
+    "build:cjs": "tsc --build ./tsconfig.cjs.json && echo \"{ \\\"type\\\": \\\"commonjs\\\" }\" > dist/cjs/package.json",
+    "build:bundle": "rollup --config ./rollup.config.ts --configPlugin typescript",
+    "build": "npm run build:esm && npm run build:cjs && npm run build:bundle",
     "test": "nyc mocha --config ../../.mocharc.json"
   },
   "bugs": {

--- a/packages/adblocker-extended-selectors/rollup.config.ts
+++ b/packages/adblocker-extended-selectors/rollup.config.ts
@@ -11,7 +11,7 @@ import terser from '@rollup/plugin-terser';
 
 export default [
   {
-    input: './dist/src/adblocker.js',
+    input: './dist/esm/adblocker.js',
     output: {
       file: './dist/adblocker.umd.min.js',
       format: 'umd',
@@ -19,31 +19,11 @@ export default [
       sourcemap: true,
     },
     plugins: [
-      resolve(),
       terser({
         output: {
           comments: false,
         },
       }),
     ],
-  },
-  {
-    input: './dist/src/adblocker.js',
-    output: [
-      {
-        dir: './dist/esm',
-        format: 'esm',
-        preserveModules: true,
-        entryFileNames: '[name].js',
-        sourcemap: true,
-      },
-      {
-        dir: './dist/cjs',
-        format: 'cjs',
-        preserveModules: true,
-        entryFileNames: '[name].cjs',
-        sourcemap: true,
-      },
-    ],
-  },
+  }
 ];

--- a/packages/adblocker-extended-selectors/src/eval.ts
+++ b/packages/adblocker-extended-selectors/src/eval.ts
@@ -6,7 +6,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-import type { AST } from './types';
+import type { AST } from './types.js';
 
 export function matchPattern(pattern: string, text: string): boolean {
   // TODO - support 'm' RegExp argument

--- a/packages/adblocker-extended-selectors/src/extended.ts
+++ b/packages/adblocker-extended-selectors/src/extended.ts
@@ -6,7 +6,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-import { tokenize, RECURSIVE_PSEUDO_CLASSES } from './parse';
+import { tokenize, RECURSIVE_PSEUDO_CLASSES } from './parse.js';
 
 export const EXTENDED_PSEUDO_CLASSES = new Set([
   // '-abp-contains',

--- a/packages/adblocker-extended-selectors/src/parse.ts
+++ b/packages/adblocker-extended-selectors/src/parse.ts
@@ -25,7 +25,7 @@
  * SOFTWARE.
  */
 
-import { isAST, isAtoms } from './types';
+import { isAST, isAtoms } from './types.js';
 import type {
   AST,
   Atoms,
@@ -41,7 +41,7 @@ import type {
   Strings,
   TokenType,
   Type,
-} from './types';
+} from './types.js';
 
 export const RECURSIVE_PSEUDO_CLASSES = new Set([
   'any',

--- a/packages/adblocker-extended-selectors/tsconfig.cjs.json
+++ b/packages/adblocker-extended-selectors/tsconfig.cjs.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "outDir": "./dist/cjs",
+  }
+}

--- a/packages/adblocker-extended-selectors/tsconfig.json
+++ b/packages/adblocker-extended-selectors/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
-    "outDir": "./dist/src",
-    "declarationDir": "./dist/types",
+    "outDir": "./dist/esm",
   },
   "include": [
     "./adblocker.ts",


### PR DESCRIPTION
This is another approach to export typescript type declarations in a way that can be consumed by every project out there.

Previous [work](https://github.com/ghostery/adblocker/pull/4061) based on @rollup/plugin-typescript` failed as type declarations were emitted with file extensions.

In this approach, we let typescript to emit both source and the declarations. But as typescript is incapable of changing the file extensions to `cjs`, we force module resolution by adding special package.json files in the build output. 

This change forces us to use file extensions in all relative import, which may be a beneficial change as the ecosystem is moving to that standard anyways.