### PR TITLE
Self-contained electron preload script with rollup

### DIFF
--- a/packages/adblocker-electron-preload/package.json
+++ b/packages/adblocker-electron-preload/package.json
@@ -8,13 +8,6 @@
   "homepage": "https://github.com/ghostery/adblocker#readme",
   "license": "MPL-2.0",
   "type": "module",
-  "tshy": {
-    "project": "./tsconfig.json",
-    "exports": {
-      "./package.json": "./package.json",
-      ".": "./src/index.js"
-    }
-  },
   "files": [
     "LICENSE",
     "dist"
@@ -31,9 +24,9 @@
     "url": "https://github.com/ghostery/adblocker/issues"
   },
   "scripts": {
-    "clean": "rimraf dist coverage .tshy .tshy-build .nyc_output .rollup.cache",
+    "clean": "rimraf dist coverage .nyc_output .rollup.cache",
     "lint": "eslint src",
-    "build": "tshy"
+    "build": "rollup --config ./rollup.config.ts --configPlugin typescript"
   },
   "peerDependencies": {
     "electron": ">11"
@@ -42,11 +35,14 @@
     "@cliqz/adblocker-content": "^1.28.0"
   },
   "devDependencies": {
+    "@rollup/plugin-commonjs": "^26.0.1",
+    "@rollup/plugin-node-resolve": "^15.2.3",
+    "@rollup/plugin-typescript": "^11.1.6",
     "@types/chrome": "^0.0.268",
     "electron": "^31.0.0",
     "eslint": "^9.3.0",
     "rimraf": "^5.0.1",
-    "tshy": "^3.0.2",
+    "rollup": "^4.18.1",
     "typescript": "^5.5.2"
   },
   "contributors": [
@@ -87,16 +83,16 @@
     "./package.json": "./package.json",
     ".": {
       "import": {
-        "types": "./dist/esm/index.d.ts",
-        "default": "./dist/esm/index.js"
+        "types": "./dist/types/src/index.d.ts",
+        "default": "./dist/index.js"
       },
       "require": {
-        "types": "./dist/commonjs/index.d.ts",
-        "default": "./dist/commonjs/index.js"
+        "types": "./dist/types/src/index.d.cts",
+        "default": "./dist/index.cjs"
       }
     }
   },
-  "main": "./dist/commonjs/index.js",
-  "types": "./dist/commonjs/index.d.ts",
-  "module": "./dist/esm/index.js"
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/types/src/index.d.ts"
 }

--- a/packages/adblocker-electron-preload/rollup.config.ts
+++ b/packages/adblocker-electron-preload/rollup.config.ts
@@ -1,0 +1,73 @@
+/*!
+ * Copyright (c) 2017-present Cliqz GmbH. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import typescript from '@rollup/plugin-typescript';
+import { nodeResolve } from '@rollup/plugin-node-resolve';
+import commonjs from '@rollup/plugin-commonjs'
+import { copyFile, rm } from 'fs/promises';
+import { existsSync } from 'fs';
+
+const dtsPath = './dist/types/src/index.d.ts'
+
+export default
+  {
+    input: './src/index.ts',
+    output: [
+      {
+        file: './dist/index.cjs',
+        format: 'cjs',
+        sourcemap: true,
+      },
+      {
+        file: './dist/index.js',
+        format: 'esm',
+        sourcemap: true,
+      }
+    ],
+    plugins: [
+      nodeResolve({
+        browser: true,
+        resolveOnly(module) {
+          return module !== 'electron'
+        },
+      }),
+      commonjs(),
+      typescript({
+        compilerOptions: {
+          declarationDir: './dist/types',
+        },
+      }),
+      {
+        name: 'cts',
+        writeBundle: {
+          sequential: true,
+          order: 'post',
+          async handler() {
+            if (existsSync(dtsPath)) {
+              const ctsPath = dtsPath.replace(/\.d\.ts$/, '.d.cts');
+              await copyFile(dtsPath, ctsPath);
+              console.log('[cts] ' + dtsPath + ' → ' + ctsPath);
+            } else {
+              console.error('[cts] source declaration: ' + dtsPath + ' was not found!');
+              console.error('[cts] check if the previous build stage has ended gracefully!');
+            }
+          },
+        },
+        options: {
+          sequential: true,
+          order: 'pre',
+          async handler() {
+            if (existsSync(dtsPath)) {
+              await rm(dtsPath);
+              console.warn('[cts] cleaned up ' + dtsPath);
+            }
+          },
+        },
+      }
+    ],
+  };

--- a/packages/adblocker-electron-preload/tsconfig.json
+++ b/packages/adblocker-electron-preload/tsconfig.json
@@ -5,5 +5,8 @@
   ],
   "files": [
     "./src/index.ts"
-  ]
+  ],
+  "compilerOptions": {
+    "outDir": "./dist",
+  },
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -406,11 +406,14 @@ __metadata:
   resolution: "@cliqz/adblocker-electron-preload@workspace:packages/adblocker-electron-preload"
   dependencies:
     "@cliqz/adblocker-content": "npm:^1.28.0"
+    "@rollup/plugin-commonjs": "npm:^26.0.1"
+    "@rollup/plugin-node-resolve": "npm:^15.2.3"
+    "@rollup/plugin-typescript": "npm:^11.1.6"
     "@types/chrome": "npm:^0.0.268"
     electron: "npm:^31.0.0"
     eslint: "npm:^9.3.0"
     rimraf: "npm:^5.0.1"
-    tshy: "npm:^3.0.2"
+    rollup: "npm:^4.18.1"
     typescript: "npm:^5.5.2"
   peerDependencies:
     electron: ">11"
@@ -8767,7 +8770,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rollup@npm:^4.0.2, rollup@npm:^4.17.2":
+"rollup@npm:^4.0.2, rollup@npm:^4.17.2, rollup@npm:^4.18.1":
   version: 4.18.1
   resolution: "rollup@npm:4.18.1"
   dependencies:


### PR DESCRIPTION
This PR replaces tshy with rollup only for electron-preload package to support electron properly.