### PR TITLE
Enforce PR labels

### DIFF
--- a/.github/workflows/enforce-labels.yml
+++ b/.github/workflows/enforce-labels.yml
@@ -1,0 +1,12 @@
+name: Enforce PR labels
+
+on:
+  pull_request:
+    types: [labeled, unlabeled, opened, edited, synchronize]
+jobs:
+  enforce-label:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: yogevbd/enforce-label-action@2.1.0
+      with:
+        REQUIRED_LABELS_ANY: "PR: Breaking Change :boom:, PR: Bug Fix :bug:, PR: Dependencies :nut_and_bolt:, PR: Docs :memo:, PR: Internal :house:, PR: New Feature :rocket:, PR: Performance :running_woman:, PR: Polish :nail_care:"

--- a/.github/workflows/enforce-labels.yml
+++ b/.github/workflows/enforce-labels.yml
@@ -9,4 +9,5 @@ jobs:
     steps:
     - uses: yogevbd/enforce-label-action@2.1.0
       with:
-        REQUIRED_LABELS_ANY: "PR: Breaking Change :boom:, PR: Bug Fix :bug:, PR: Dependencies :nut_and_bolt:, PR: Docs :memo:, PR: Internal :house:, PR: New Feature :rocket:, PR: Performance :running_woman:, PR: Polish :nail_care:"
+        REQUIRED_LABELS_ANY: "PR: Breaking Change :boom:,PR: Bug Fix :bug:,PR: Dependencies :nut_and_bolt:,PR: Docs :memo:,PR: Internal :house:,PR: New Feature :rocket:,PR: Performance :running_woman:,PR: Polish :nail_care:"
+        REQUIRED_LABELS_ANY_DESCRIPTION: "Select at least one label: PR: Breaking Change :boom:, PR: Bug Fix :bug:, PR: Dependencies :nut_and_bolt:, PR: Docs :memo:, PR: Internal :house:, PR: New Feature :rocket:, PR: Performance :running_woman:, PR: Polish :nail_care:"

--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.3.0",
-    "@remusao/auto-config": "^1.1.2",
     "@types/benchmark": "^2.1.3",
     "@types/node": "^20.12.12",
     "auto": "^11.0.5",
@@ -85,9 +84,84 @@
     "typescript-eslint": "8.0.0-alpha.44"
   },
   "auto": {
-    "extends": "@remusao/auto-config",
     "name": "Ghostery Adblocker Bot",
-    "email": "ghostery-adblocker-bot@users.noreply.github.com"
+    "email": "ghostery-adblocker-bot@users.noreply.github.com",
+    "plugins": [
+      "npm"
+    ],
+    "labels": [
+      {
+        "name": "PR: Breaking Change :boom:",
+        "description": "Increment major version when merged",
+        "changelogTitle": ":boom: Breaking Change",
+        "releaseType": "major",
+        "overwrite": true,
+        "color": "#e2372b"
+      },
+      {
+        "name": "PR: New Feature :rocket:",
+        "description": "Increment minor version when merged",
+        "changelogTitle": ":rocket: New Feature",
+        "releaseType": "minor",
+        "overwrite": true,
+        "color": "#2e449b"
+      },
+      {
+        "name": "PR: Performance :running_woman:",
+        "description": "Increment minor version when merged",
+        "changelogTitle": ":running_woman: Performance",
+        "releaseType": "minor",
+        "overwrite": true,
+        "color": "#ead99f"
+      },
+      {
+        "name": "PR: Bug Fix :bug:",
+        "description": "Increment patch version when merged",
+        "changelogTitle": ":bug: Bug Fix",
+        "releaseType": "patch",
+        "overwrite": true,
+        "color": "#56dd97"
+      },
+      {
+        "name": "PR: Polish :nail_care:",
+        "description": "Increment patch version when merged",
+        "changelogTitle": ":nail_care: Polish",
+        "releaseType": "patch",
+        "overwrite": true,
+        "color": "#a9bbe8"
+      },
+      {
+        "name": "PR: Internal :house:",
+        "description": "Changes only affect internals",
+        "changelogTitle": ":house: Internal",
+        "releaseType": "none",
+        "overwrite": true,
+        "color": "#5b1482"
+      },
+      {
+        "name": "PR: Docs :memo:",
+        "description": "Changes only affect documentation",
+        "changelogTitle": ":memo: Documentation",
+        "releaseType": "none",
+        "overwrite": true,
+        "color": "#d2f28a"
+      },
+      {
+        "name": "skip-release",
+        "description": "Preserve the current version when merged",
+        "releaseType": "skip",
+        "overwrite": true,
+        "color": "#e069cf"
+      },
+      {
+        "name": "PR: Dependencies :nut_and_bolt:",
+        "description": "Changes only update dependencies",
+        "changelogTitle": ":nut_and_bolt: Dependencies",
+        "releaseType": "none",
+        "overwrite": true,
+        "color": "#5dbdcc"
+      }
+    ]
   },
   "packageManager": "yarn@4.2.2"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1783,15 +1783,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@remusao/auto-config@npm:^1.1.2":
-  version: 1.2.0
-  resolution: "@remusao/auto-config@npm:1.2.0"
-  peerDependencies:
-    auto: "*"
-  checksum: 10/35db7258b69d2e4f3c9a2c9b486c07c19b8f191c0bf6e80fcdebcd8b64c33e3b005837661e62e660dcad4324d88203d79922364a71b27c3e5b6569317bcc41fc
-  languageName: node
-  linkType: hard
-
 "@remusao/counter@npm:^1.4.0":
   version: 1.4.0
   resolution: "@remusao/counter@npm:1.4.0"
@@ -2643,7 +2634,6 @@ __metadata:
   resolution: "adblocker@workspace:."
   dependencies:
     "@eslint/js": "npm:^9.3.0"
-    "@remusao/auto-config": "npm:^1.1.2"
     "@types/benchmark": "npm:^2.1.3"
     "@types/node": "npm:^20.12.12"
     auto: "npm:^11.0.5"


### PR DESCRIPTION
Additionally, `@remusao/auto-config` was removed as it was restraining repository labels. 