### PR TITLE
Feedback from not supported filters

### DIFF
--- a/packages/adblocker/src/lists.ts
+++ b/packages/adblocker/src/lists.ts
@@ -279,22 +279,19 @@ export function parseFilters(
             }),
           );
         }
-      } else {
-        if (filterType === FilterType.NOT_SUPPORTED_ADGUARD) {
-          notSupportedFilters.push({
-            lineNumber: i,
-            filter: line,
-            filterType,
-          });
-        }
-      }
-    } else {
-      if (filterType === FilterType.NOT_SUPPORTED_ADGUARD) {
+      } else if (filterType === FilterType.NOT_SUPPORTED_ADGUARD) {
         notSupportedFilters.push({
           lineNumber: i,
           filter: line,
           filterType,
         });
+      }
+    } else if (filterType === FilterType.NOT_SUPPORTED_ADGUARD) {
+      notSupportedFilters.push({
+        lineNumber: i,
+        filter: line,
+        filterType,
+      });
       }
     }
   }

--- a/packages/adblocker/src/lists.ts
+++ b/packages/adblocker/src/lists.ts
@@ -166,13 +166,13 @@ export function parseFilters(
   networkFilters: NetworkFilter[];
   cosmeticFilters: CosmeticFilter[];
   preprocessors: Preprocessor[];
-  notSupportedFilters: nonSupportedFilter[];
+  notSupportedFilters: NonSupportedFilter[];
 } {
   config = new Config(config);
 
   const networkFilters: NetworkFilter[] = [];
   const cosmeticFilters: CosmeticFilter[] = [];
-  const notSupportedFilters: nonSupportedFilter[] = [];
+  const notSupportedFilters: NonSupportedFilter[] = [];
   const lines = list.split('\n');
 
   const preprocessors: Preprocessor[] = [];

--- a/packages/adblocker/src/lists.ts
+++ b/packages/adblocker/src/lists.ts
@@ -292,7 +292,6 @@ export function parseFilters(
         filter: line,
         filterType,
       });
-      }
     }
   }
 

--- a/packages/adblocker/src/lists.ts
+++ b/packages/adblocker/src/lists.ts
@@ -30,7 +30,7 @@ export const enum FilterType {
  */
 export function detectFilterType(
   line: string,
-  { extendedNonSupportedTypes }: { extendedNonSupportedTypes?: boolean } = {},
+  { extendedNonSupportedTypes = false } = {},
 ): FilterType {
   // Ignore empty line
   if (line.length === 0 || line.length === 1) {

--- a/packages/adblocker/src/lists.ts
+++ b/packages/adblocker/src/lists.ts
@@ -153,7 +153,7 @@ export function f(strings: TemplateStringsArray): NetworkFilter | CosmeticFilter
   return parseFilter(strings[0]);
 }
 
-interface nonSupportedFilter {
+interface NonSupportedFilter {
   lineNumber: number;
   filter: string;
   filterType: FilterType;

--- a/packages/adblocker/test/lists.test.ts
+++ b/packages/adblocker/test/lists.test.ts
@@ -40,55 +40,61 @@ describe('#detectFilterType', () => {
   const networkFilter = 'foo.com';
   const cosmeticFilter = '###test';
 
+  const expectType = (filter: string, filterType: FilterType) =>
+    expect(detectFilterType(filter)).to.equal(filterType, filter);
+
   it('detects NETWORK filters', () => {
-    expect(detectFilterType(networkFilter)).to.equal(FilterType.NETWORK);
+    expectType(networkFilter, FilterType.NETWORK);
   });
 
   it('detects COSMETIC filters', () => {
-    expect(detectFilterType(cosmeticFilter)).to.equal(FilterType.COSMETIC);
+    expectType(cosmeticFilter, FilterType.COSMETIC);
   });
 
   it('detects NON_SUPPORTED filters', () => {
-    expect(detectFilterType('')).to.equal(FilterType.NOT_SUPPORTED);
-    expect(detectFilterType(`a`)).to.equal(FilterType.NOT_SUPPORTED);
-    expect(detectFilterType('! some comment')).to.equal(FilterType.NOT_SUPPORTED);
-    expect(detectFilterType(`!${networkFilter}`)).to.equal(FilterType.NOT_SUPPORTED);
-    expect(detectFilterType(`!${cosmeticFilter}`)).to.equal(FilterType.NOT_SUPPORTED);
-    expect(detectFilterType(`!${cosmeticFilter}`)).to.equal(FilterType.NOT_SUPPORTED);
-    expect(detectFilterType(`[Adblock]`)).to.equal(FilterType.NOT_SUPPORTED);
+    expectType('', FilterType.NOT_SUPPORTED);
+    expectType(`a`, FilterType.NOT_SUPPORTED);
+    expectType('! some comment', FilterType.NOT_SUPPORTED);
+    expectType(`!${networkFilter}`, FilterType.NOT_SUPPORTED);
+    expectType(`!${cosmeticFilter}`, FilterType.NOT_SUPPORTED);
+    expectType(`!${cosmeticFilter}`, FilterType.NOT_SUPPORTED);
+    expectType(`[Adblock]`, FilterType.NOT_SUPPORTED);
     for (const adguardFilter of ADGUARD_FILTERS) {
-      expect(detectFilterType(adguardFilter)).to.equal(FilterType.NOT_SUPPORTED, adguardFilter);
+      expectType(adguardFilter, FilterType.NOT_SUPPORTED);
     }
   });
 
   context('with extendedNonSupportedTypes option', () => {
-    const subject = (filter: string) =>
-      detectFilterType(filter, { extendedNonSupportedTypes: true });
+    const expectType = (filter: string, filterType: FilterType) =>
+      expect(detectFilterType(filter, { extendedNonSupportedTypes: true })).to.equal(
+        filterType,
+        filter,
+      );
 
     it('detects NETWORK filters', () => {
-      expect(subject(networkFilter)).to.equal(FilterType.NETWORK);
+      expectType(networkFilter, FilterType.NETWORK);
     });
 
     it('detects COSMETIC filters', () => {
-      expect(subject(cosmeticFilter)).to.equal(FilterType.COSMETIC);
+      expectType(cosmeticFilter, FilterType.COSMETIC);
     });
 
     it('detects NOT_SUPPORTED_EMPTY filters', () => {
-      expect(subject('')).to.equal(FilterType.NOT_SUPPORTED_EMPTY);
-      expect(subject(`a`)).to.equal(FilterType.NOT_SUPPORTED_EMPTY);
+      expectType('', FilterType.NOT_SUPPORTED_EMPTY);
+      expectType(`a`, FilterType.NOT_SUPPORTED_EMPTY);
     });
 
     it('detects NOT_SUPPORTED_COMMENT filters', () => {
-      expect(subject('! some comment')).to.equal(FilterType.NOT_SUPPORTED_COMMENT);
-      expect(subject(`!${networkFilter}`)).to.equal(FilterType.NOT_SUPPORTED_COMMENT);
-      expect(subject(`!${cosmeticFilter}`)).to.equal(FilterType.NOT_SUPPORTED_COMMENT);
-      expect(subject(`!${cosmeticFilter}`)).to.equal(FilterType.NOT_SUPPORTED_COMMENT);
-      expect(subject(`[Adblock]`)).to.equal(FilterType.NOT_SUPPORTED_COMMENT);
+      expectType('! some comment', FilterType.NOT_SUPPORTED_COMMENT);
+      expectType(`!${networkFilter}`, FilterType.NOT_SUPPORTED_COMMENT);
+      expectType(`!${cosmeticFilter}`, FilterType.NOT_SUPPORTED_COMMENT);
+      expectType(`!${cosmeticFilter}`, FilterType.NOT_SUPPORTED_COMMENT);
+      expectType(`[Adblock]`, FilterType.NOT_SUPPORTED_COMMENT);
     });
 
     it('detects NOT_SUPPORTED_ADGUARD filters', () => {
       for (const adguardFilter of ADGUARD_FILTERS) {
-        expect(subject(adguardFilter)).to.equal(FilterType.NOT_SUPPORTED_ADGUARD, adguardFilter);
+        expectType(adguardFilter, FilterType.NOT_SUPPORTED_ADGUARD);
       }
     });
   });


### PR DESCRIPTION
Ghostery extension is going to allow users add own filters. To make this experience easier, it would be great to receive feedback if a filter is invalid or not supported. 