### PR TITLE
chore: drop `const enum` for `FilterType`

### DIFF
--- a/packages/adblocker/src/lists.ts
+++ b/packages/adblocker/src/lists.ts
@@ -12,7 +12,7 @@ import NetworkFilter from './filters/network.js';
 import Preprocessor, { PreprocessorTokens, detectPreprocessor } from './preprocessor.js';
 import { fastStartsWith, fastStartsWithFrom } from './utils.js';
 
-export const enum FilterType {
+export enum FilterType {
   NOT_SUPPORTED = 0,
   NETWORK = 1,
   COSMETIC = 2,


### PR DESCRIPTION
Using `const enum` in exported properties can be a huge disadvantage for JavaScript-only environment. The enum will be hardcoded into the source-code using the constant rather than exported as a value.

Further discussion:
- Should we drop `const enum` globally? or in just exported properties.

I found that the only exported enum value is `FilterType`. However, we might consider using normal enum instead of `const enum` for `COSMETICS_MASK` and `NETWORK_FILTER_MASK`.

These changes won't affect to the performance (I expect less than 2% of difference by this changes, which is in error range).