### PR TITLE
feat: respect aliases in scriptlet exceptions

### DIFF
--- a/packages/adblocker/src/engine/engine.ts
+++ b/packages/adblocker/src/engine/engine.ts
@@ -883,6 +883,12 @@ export default class FilterEngine extends EventEmitter<EngineEventHandlers> {
       ) {
         injectionsDisabled = true;
       }
+      console.log(
+        'normalised',
+        unhide.getNormalizedScriptInjectionSelector(this.resources.js),
+        'normal',
+        unhide.getSelector(),
+      );
       unhideExceptions.set(
         unhide.getNormalizedScriptInjectionSelector(this.resources.js) ?? unhide.getSelector(),
         unhide,

--- a/packages/adblocker/src/engine/engine.ts
+++ b/packages/adblocker/src/engine/engine.ts
@@ -883,7 +883,10 @@ export default class FilterEngine extends EventEmitter<EngineEventHandlers> {
       ) {
         injectionsDisabled = true;
       }
-      unhideExceptions.set(unhide.getSelector(), unhide);
+      unhideExceptions.set(
+        unhide.getNormalizedScriptInjectionSelector(this.resources.js) ?? unhide.getSelector(),
+        unhide,
+      );
     }
 
     const injections: CosmeticFilter[] = [];
@@ -894,7 +897,9 @@ export default class FilterEngine extends EventEmitter<EngineEventHandlers> {
       // Apply unhide rules + dispatch
       for (const filter of filters) {
         // Make sure `rule` is not un-hidden by a #@# filter
-        const exception = unhideExceptions.get(filter.getSelector());
+        const exception = unhideExceptions.get(
+          filter.getNormalizedScriptInjectionSelector(this.resources.js) ?? filter.getSelector(),
+        );
 
         if (exception !== undefined) {
           continue;

--- a/packages/adblocker/src/engine/engine.ts
+++ b/packages/adblocker/src/engine/engine.ts
@@ -883,12 +883,6 @@ export default class FilterEngine extends EventEmitter<EngineEventHandlers> {
       ) {
         injectionsDisabled = true;
       }
-      console.log(
-        'normalised',
-        unhide.getNormalizedScriptInjectionSelector(this.resources.js),
-        'normal',
-        unhide.getSelector(),
-      );
       unhideExceptions.set(
         unhide.getNormalizedScriptInjectionSelector(this.resources.js) ?? unhide.getSelector(),
         unhide,

--- a/packages/adblocker/src/engine/engine.ts
+++ b/packages/adblocker/src/engine/engine.ts
@@ -884,7 +884,7 @@ export default class FilterEngine extends EventEmitter<EngineEventHandlers> {
         injectionsDisabled = true;
       }
       unhideExceptions.set(
-        unhide.getNormalizedScriptInjectionSelector(this.resources.js) ?? unhide.getSelector(),
+        unhide.getNormalizedSelector(this.resources.js) ?? unhide.getSelector(),
         unhide,
       );
     }
@@ -898,7 +898,7 @@ export default class FilterEngine extends EventEmitter<EngineEventHandlers> {
       for (const filter of filters) {
         // Make sure `rule` is not un-hidden by a #@# filter
         const exception = unhideExceptions.get(
-          filter.getNormalizedScriptInjectionSelector(this.resources.js) ?? filter.getSelector(),
+          filter.getNormalizedSelector(this.resources.js) ?? filter.getSelector(),
         );
 
         if (exception !== undefined) {

--- a/packages/adblocker/src/filters/cosmetic.ts
+++ b/packages/adblocker/src/filters/cosmetic.ts
@@ -810,12 +810,12 @@ export default class CosmeticFilter implements IFilter {
       return undefined;
     }
 
-    const originResourceName = js.get(selector.slice(1, firstCommaIndex))?.aliasOf;
+    const originResourceName = js.get(selector.slice(0, firstCommaIndex))?.aliasOf;
     if (originResourceName === undefined) {
       return undefined;
     }
 
-    return '(' + originResourceName + selector.slice(firstCommaIndex);
+    return originResourceName + selector.slice(firstCommaIndex);
   }
 
   public hasHostnameConstraint(): boolean {

--- a/packages/adblocker/src/filters/cosmetic.ts
+++ b/packages/adblocker/src/filters/cosmetic.ts
@@ -798,7 +798,7 @@ export default class CosmeticFilter implements IFilter {
     return undefined;
   }
 
-  public getNormalizedScriptInjectionSelector(js: Map<string, Resource>): string | undefined {
+  public getNormalizedSelector(js: Map<string, Resource>): string | undefined {
     if (this.isScriptInject() === false) {
       return undefined;
     }

--- a/packages/adblocker/src/filters/cosmetic.ts
+++ b/packages/adblocker/src/filters/cosmetic.ts
@@ -805,9 +805,9 @@ export default class CosmeticFilter implements IFilter {
 
     const selector = this.getSelector();
 
-    const firstCommaIndex = selector.indexOf(',');
+    let firstCommaIndex = selector.indexOf(',');
     if (firstCommaIndex === -1) {
-      return undefined;
+      firstCommaIndex = selector.length;
     }
 
     const originResourceName = js.get(selector.slice(0, firstCommaIndex))?.aliasOf;

--- a/packages/adblocker/src/resources.ts
+++ b/packages/adblocker/src/resources.ts
@@ -8,7 +8,7 @@
 
 import { getResourceForMime } from '@remusao/small';
 
-import { StaticDataView, sizeOfUTF8, sizeOfASCII, sizeOfByte } from './data-view.js';
+import { StaticDataView, sizeOfUTF8, sizeOfASCII, sizeOfByte, sizeOfBool } from './data-view.js';
 
 // Polyfill for `btoa`
 function btoaPolyfill(buffer: string): string {
@@ -191,7 +191,7 @@ export default class Resources {
     let estimatedSize = sizeOfASCII(this.checksum) + 2 * sizeOfByte(); // resources.size
 
     this.resources.forEach(({ contentType, body, aliasOf }, name) => {
-      estimatedSize += sizeOfASCII(name);
+      estimatedSize += sizeOfASCII(name) + sizeOfBool();
       if (aliasOf === undefined) {
         estimatedSize += sizeOfASCII(contentType) + sizeOfUTF8(body);
       } else {
@@ -210,6 +210,7 @@ export default class Resources {
     buffer.pushUint16(this.resources.size);
     this.resources.forEach(({ contentType, body, aliasOf }, name) => {
       buffer.pushASCII(name);
+      buffer.pushBool(aliasOf === undefined);
       if (aliasOf === undefined) {
         buffer.pushASCII(contentType);
         buffer.pushUTF8(body);

--- a/packages/adblocker/test/engine/engine.test.ts
+++ b/packages/adblocker/test/engine/engine.test.ts
@@ -713,7 +713,10 @@ foo.com###selector
 
       it('disabling specific hides does not impact scriptlets', () => {
         const engine = Engine.parse(['@@||foo.com^$specifichide', 'foo.com##+js(foo)'].join('\n'));
-        engine.resources.js.set('foo', '');
+        engine.resources.js.set('foo', {
+          contentType: 'application/javascript',
+          body: '',
+        });
         expect(
           engine.getCosmeticsFilters({
             domain: 'foo.com',
@@ -1300,9 +1303,18 @@ foo.com###selector
         it(JSON.stringify({ filters, hostname, matches, injections }), () => {
           // Initialize engine with all rules from test case
           const engine = createEngine(filters.join('\n'));
-          engine.resources.js.set('scriptlet', 'scriptlet');
-          engine.resources.js.set('scriptlet1', 'scriptlet1');
-          engine.resources.js.set('scriptlet2', 'scriptlet2');
+          engine.resources.js.set('scriptlet', {
+            contentType: 'application/javascript',
+            body: 'scriptlet',
+          });
+          engine.resources.js.set('scriptlet1', {
+            contentType: 'application/javascript',
+            body: 'scriptlet1',
+          });
+          engine.resources.js.set('scriptlet2', {
+            contentType: 'application/javascript',
+            body: 'scriptlet2',
+          });
 
           // #getCosmeticsFilters
           const { styles, scripts } = engine.getCosmeticsFilters({

--- a/packages/adblocker/test/engine/engine.test.ts
+++ b/packages/adblocker/test/engine/engine.test.ts
@@ -885,6 +885,20 @@ foo.com###selector
         injections: [],
         matches: [],
       },
+      {
+        filters: ['foo.com##+js(alias)', 'foo.com#@#+js(scriptlet)'],
+        hostname: 'foo.com',
+        hrefs: [],
+        injections: [],
+        matches: [],
+      },
+      {
+        filters: ['foo.com##+js(scriptlet)', 'foo.com#@#+js(alias)'],
+        hostname: 'foo.com',
+        hrefs: [],
+        injections: [],
+        matches: [],
+      },
 
       // = unhide +js() disable
       {
@@ -1314,6 +1328,12 @@ foo.com###selector
           engine.resources.js.set('scriptlet2', {
             contentType: 'application/javascript',
             body: 'scriptlet2',
+          });
+
+          engine.resources.js.set('alias', {
+            contentType: 'application/javascript',
+            body: 'scriptlet',
+            aliasOf: 'scriptlet',
           });
 
           // #getCosmeticsFilters

--- a/packages/adblocker/test/engine/engine.test.ts
+++ b/packages/adblocker/test/engine/engine.test.ts
@@ -387,13 +387,14 @@ $csp=baz,domain=bar.com
       url: 'https://foo.com',
     });
 
-    const createEngineWithResource = (filters: string[], resource: string) => {
+    const createEngineWithResource = (filters: string[], resourceBody: string) => {
       const engine = createEngine(filters.join('\n'));
-      engine.resources.js.set(resource, resource);
-      engine.resources.resources.set(resource, {
-        body: resource,
+      const resource = {
+        body: resourceBody,
         contentType: 'application/javascript',
-      });
+      };
+      engine.resources.js.set(resourceBody, resource);
+      engine.resources.resources.set(resourceBody, resource);
       return engine;
     };
 

--- a/packages/adblocker/test/parsing.test.ts
+++ b/packages/adblocker/test/parsing.test.ts
@@ -1836,7 +1836,7 @@ describe('Cosmetic filters', () => {
       // Compound
       test('script:has-text(===):has-text(/[wW]{14000}/)', ['script', ['===', '/[wW]{14000}/']]);
 
-      context('with normalization', () => {
+      it('with normalization', () => {
         const js = new Map<string, Resource>([
           [
             'scriptlet',
@@ -1855,17 +1855,12 @@ describe('Cosmetic filters', () => {
           ],
         ]);
 
-        expect(CosmeticFilter.parse('##+js(scriptlet)')!.getNormalizedSelector(js)).to.be(
+        expect(CosmeticFilter.parse('foo.com##+js(alias)')!.getNormalizedSelector(js)).to.be.eql(
           'scriptlet',
         );
-        expect(CosmeticFilter.parse('##+js(alias)')!.getNormalizedSelector(js)).to.be('scriptlet');
-
-        expect(CosmeticFilter.parse('##+js(scriptlet, arg1)')!.getNormalizedSelector(js)).to.be(
-          'scriptlet, arg1',
-        );
-        expect(CosmeticFilter.parse('##+js(alias, arg1)')!.getNormalizedSelector(js)).to.be(
-          'scriptlet, arg1',
-        );
+        expect(
+          CosmeticFilter.parse('foo.com##+js(alias, arg1)')!.getNormalizedSelector(js),
+        ).to.be.eql('scriptlet, arg1');
       });
     });
   });

--- a/packages/adblocker/test/parsing.test.ts
+++ b/packages/adblocker/test/parsing.test.ts
@@ -15,6 +15,7 @@ import { parseFilters } from '../src/lists.js';
 import { hashStrings, tokenize } from '../src/utils.js';
 import { HTMLSelector } from '../src/html-filtering.js';
 import { NORMALIZED_TYPE_TOKEN, hashHostnameBackward } from '../src/request.js';
+import { Resource } from '../src/resources.js';
 
 function h(hostnames: string[]): Uint32Array {
   return new Uint32Array(hostnames.map(hashHostnameBackward)).sort();
@@ -1834,6 +1835,38 @@ describe('Cosmetic filters', () => {
 
       // Compound
       test('script:has-text(===):has-text(/[wW]{14000}/)', ['script', ['===', '/[wW]{14000}/']]);
+
+      context('with normalization', () => {
+        const js = new Map<string, Resource>([
+          [
+            'scriptlet',
+            {
+              body: 'scriptlet',
+              contentType: 'application/javascript',
+            },
+          ],
+          [
+            'alias',
+            {
+              body: 'scriptlet',
+              contentType: 'application/javascript',
+              aliasOf: 'scriptlet',
+            },
+          ],
+        ]);
+
+        expect(CosmeticFilter.parse('##+js(scriptlet)')!.getNormalizedSelector(js)).to.be(
+          'scriptlet',
+        );
+        expect(CosmeticFilter.parse('##+js(alias)')!.getNormalizedSelector(js)).to.be('scriptlet');
+
+        expect(CosmeticFilter.parse('##+js(scriptlet, arg1)')!.getNormalizedSelector(js)).to.be(
+          'scriptlet, arg1',
+        );
+        expect(CosmeticFilter.parse('##+js(alias, arg1)')!.getNormalizedSelector(js)).to.be(
+          'scriptlet, arg1',
+        );
+      });
     });
   });
 

--- a/packages/adblocker/test/parsing.test.ts
+++ b/packages/adblocker/test/parsing.test.ts
@@ -1881,14 +1881,36 @@ describe('Cosmetic filters', () => {
     });
 
     it('returns a script if one exists', () => {
-      expect(simpleScriptlet?.getScript(new Map([['script.js', 'test']]))).to.equal('test');
+      expect(
+        simpleScriptlet?.getScript(
+          new Map([
+            [
+              'script.js',
+              {
+                contentType: 'application/javascript',
+                body: 'test',
+              },
+            ],
+          ]),
+        ),
+      ).to.equal('test');
     });
 
     context('with arguments', () => {
       it('inject values', () => {
-        expect(simpleScriptlet?.getScript(new Map([['script.js', '{{1}},{{2}},{{3}}']]))).to.equal(
-          'arg1,arg2,arg3',
-        );
+        expect(
+          simpleScriptlet?.getScript(
+            new Map([
+              [
+                'script.js',
+                {
+                  contentType: 'application/javascript',
+                  body: '{{1}},{{2}},{{3}}',
+                },
+              ],
+            ]),
+          ),
+        ).to.equal('arg1,arg2,arg3');
       });
 
       it('escapes special characters', () => {
@@ -1909,9 +1931,19 @@ describe('Cosmetic filters', () => {
           '\\',
         ]) {
           const scriptlet = CosmeticFilter.parse(`foo.com##+js(script.js, ${character})`);
-          expect(scriptlet?.getScript(new Map([['script.js', '{{1}}']]))).to.equal(
-            `\\${character}`,
-          );
+          expect(
+            scriptlet?.getScript(
+              new Map([
+                [
+                  'script.js',
+                  {
+                    contentType: 'application/javascript',
+                    body: '{{1}}',
+                  },
+                ],
+              ]),
+            ),
+          ).to.equal(`\\${character}`);
         }
       });
 
@@ -1921,7 +1953,19 @@ describe('Cosmetic filters', () => {
           [String.raw`foo\*`, String.raw`foo\\\*`],
         ]) {
           const scriptlet = CosmeticFilter.parse(`foo.com##+js(script.js, ${example[0]})`);
-          expect(scriptlet?.getScript(new Map([['script.js', '{{1}}']]))).to.equal(example[1]);
+          expect(
+            scriptlet?.getScript(
+              new Map([
+                [
+                  'script.js',
+                  {
+                    contentType: 'application/javascript',
+                    body: '{{1}}',
+                  },
+                ],
+              ]),
+            ),
+          ).to.equal(example[1]);
         }
       });
     });

--- a/packages/adblocker/test/resources.test.ts
+++ b/packages/adblocker/test/resources.test.ts
@@ -37,7 +37,17 @@ describe('#Resources', () => {
         checksum: 'checksum',
       });
       expect(resources.checksum).to.equal('checksum');
-      expect(resources.js).to.eql(new Map([['foo', 'content']]));
+      expect(resources.js).to.eql(
+        new Map([
+          [
+            'foo',
+            {
+              contentType: 'application/javascript',
+              body: 'content',
+            },
+          ],
+        ]),
+      );
       expect(resources.resources).to.eql(
         new Map([['foo', { contentType: 'application/javascript', body: 'content' }]]),
       );
@@ -51,7 +61,17 @@ describe('#Resources', () => {
         { checksum: 'checksum' },
       );
       expect(resources.checksum).to.equal('checksum');
-      expect(resources.js).to.eql(new Map([['foo', 'content1']]));
+      expect(resources.js).to.eql(
+        new Map([
+          [
+            'foo',
+            {
+              contentType: 'application/javascript',
+              body: 'content1',
+            },
+          ],
+        ]),
+      );
       expect(resources.resources).to.eql(
         new Map([
           ['foo', { contentType: 'application/javascript', body: 'content1' }],
@@ -83,7 +103,17 @@ content2
         { checksum: 'checksum' },
       );
       expect(resources.checksum).to.equal('checksum');
-      expect(resources.js).to.eql(new Map([['foo', 'content1']]));
+      expect(resources.js).to.eql(
+        new Map([
+          [
+            'foo',
+            {
+              contentType: 'application/javascript',
+              body: 'content1',
+            },
+          ],
+        ]),
+      );
       expect(resources.resources).to.eql(
         new Map([
           ['foo', { contentType: 'application/javascript', body: 'content1' }],


### PR DESCRIPTION
fixes https://github.com/ghostery/adblocker/issues/4058

TODO

- [x] Add tests
- [ ] Add an ability to cache the normalised selector in somewhere
- [x] Confirm the behavior in other abilities like "resource redirects"
- [ ] Update engine serialization version (as a last action)
