### PR TITLE
ci: rollback to use v22.5.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        node: [18, 20, 22.4]
+        node: [18, 20, 22]
         os: [ubuntu-latest]
 
     steps:


### PR DESCRIPTION
This PR rolls the node version back to latest v22.

refs https://nodejs.org/en/blog/release/v22.5.1
refs https://github.com/ghostery/adblocker/pull/4119