### PR TITLE
fix(adblocker-electron): `An object could not be cloned`

### DIFF
--- a/packages/adblocker-content/src/index.ts
+++ b/packages/adblocker-content/src/index.ts
@@ -133,8 +133,8 @@ export function extractFeaturesFromDOM(roots: Element[]): {
       }
 
       // Update ids
-      const id = element.id;
-      if (id) {
+      const id = element.getAttribute('id');
+      if (typeof id === 'string') {
         ids.add(id);
       }
 


### PR DESCRIPTION
fixes https://github.com/ghostery/adblocker/issues/3327

This PR accepts the suggested solution in the above issue.

---

The problem is happening because the `id` property of `HTMLFormElement` can return `HTMLInputElement` instead of `string`, which will lead to serialization error in [structured cloning](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm). This is important in the electron to communicate with data object.

Normally, the `id` property should return the id attribute of the element but the behavior is not same in the following situation:

```html
<form>
<input name="id" />
</form>
```

Let's pick up the `form` element and try to query `element.id`. It'll return `input[name="id"]` instead of falsy string. The solution would be to use `HTMLElement.getAttribute` instead of `HTMLElement.id` which will always return string or null.