### PR TITLE
Fix retrieval of latestRevision in assets update script

### DIFF
--- a/packages/adblocker/assets/update.js
+++ b/packages/adblocker/assets/update.js
@@ -30,7 +30,7 @@ const ASSETS_PATH = dirname(fileURLToPath(import.meta.url));
 
 async function downloadResource(resourceName) {
   const {
-    revisions: [, latestRevision],
+    revisions
   } = await fetch(
     `https://cdn.ghostery.com/adblocker/resources/${resourceName}/metadata.json`,
   ).then((result) => {
@@ -41,6 +41,7 @@ async function downloadResource(resourceName) {
     }
     return result.json();
   });
+  const latestRevision = revisions.at(-1);
   return fetch(
     `https://cdn.ghostery.com/adblocker/resources/${resourceName}/${latestRevision}/list.txt`,
   ).then((result) => {


### PR DESCRIPTION
It seems that the current `update.js` script always selects the second available revision of a list or resource instead of the latest one. As a result, all the built-in filter lists are outdated. Additionally, the ublock-resources scriptlets file, [resources.txt](https://github.com/ghostery/adblocker/blob/3121425c412c52ff30b24c76b3c275a8a1cfa8ad/packages/adblocker/assets/ublock-origin/resources.txt), is missing many scriptlets that are widely used in filter lists.