### PR TITLE
Fix cosmetic filters codebook generation

### DIFF
--- a/packages/adblocker/tools/generate_compression_codebooks.ts
+++ b/packages/adblocker/tools/generate_compression_codebooks.ts
@@ -73,7 +73,13 @@ async function getStrings(kind: string): Promise<string[]> {
         .map(({ selector }) => selector || '')
         .filter((selector) => selector.length !== 0);
     case 'raw-cosmetic':
-      return (await getCosmeticFilters()).map((f) => f.toString()).filter((f) => !hasUnicode(f));
+      return (
+        (await getCosmeticFilters())
+          // ignore scriplets as their options can be very complex
+          .filter((filter) => !filter.isScriptInject())
+          .map((f) => f.toString())
+          .filter((f) => !hasUnicode(f))
+      );
     case 'raw-network':
       return (await getNetworkFilters()).map((f) => f.toString()).filter((f) => !hasUnicode(f));
     default:


### PR DESCRIPTION
This is a quick fix.

CI is running into `RangeError: Map maximum size exceeded` on the assets update job as during codebook generation scriptlets were providing to many variations for the codebook tokens. 

```
2024-08-05T07:50:59.7679660Z [build:raw-cosmetic] file:///home/runner/work/adblocker/adblocker/node_modules/@remusao/counter/dist/esm/index.js:33
2024-08-05T07:50:59.7681719Z [build:raw-cosmetic]         this.map.set(key, this.get(key) + n);
2024-08-05T07:50:59.7683000Z [build:raw-cosmetic]                  ^
2024-08-05T07:50:59.7683991Z [build:raw-cosmetic] 
2024-08-05T07:50:59.7685251Z [build:raw-cosmetic] RangeError: Map maximum size exceeded
2024-08-05T07:50:59.7686514Z [build:raw-cosmetic]     at Map.set (<anonymous>)
2024-08-05T07:50:59.7688585Z [build:raw-cosmetic]     at Counter.incr (/home/runner/work/adblocker/adblocker/node_modules/@remusao/counter/src/index.ts:41:14)
2024-08-05T07:50:59.7691537Z [build:raw-cosmetic]     at addCounts (/home/runner/work/adblocker/adblocker/node_modules/@remusao/smaz-generate/src/index.ts:95:19)
2024-08-05T07:50:59.7694230Z [build:raw-cosmetic]     at generate (/home/runner/work/adblocker/adblocker/node_modules/@remusao/smaz-generate/src/index.ts:183:3)
2024-08-05T07:50:59.7770176Z [build:raw-cosmetic]     at generateCodebook (/home/runner/work/adblocker/adblocker/packages/adblocker/tools/generate_compression_codebooks.ts:135:20)
2024-08-05T07:50:59.7773303Z [build:raw-cosmetic]     at <anonymous> (/home/runner/work/adblocker/adblocker/packages/adblocker/tools/generate_compression_codebooks.ts:142:20)
2024-08-05T07:50:59.7774898Z [build:raw-cosmetic] 
2024-08-05T07:50:59.7775610Z [build:raw-cosmetic] Node.js v22.4.1
2024-08-05T07:50:59.8592669Z [build:raw-cosmetic] yarn run codebook-raw-cosmetic exited with code 1
```