### PR TITLE
Fix FilterEngine static merge method

### DIFF
--- a/packages/adblocker/src/engine/engine.ts
+++ b/packages/adblocker/src/engine/engine.ts
@@ -242,7 +242,7 @@ export default class FilterEngine extends EventEmitter<EngineEventHandlers> {
     }
 
     const config = engines[0].config;
-    const lists = engines[0].lists;
+    const lists = new Map();
 
     const networkFilters: Map<number, NetworkFilter> = new Map();
     const cosmeticFilters: Map<number, CosmeticFilter> = new Map();

--- a/packages/adblocker/test/engine/engine.test.ts
+++ b/packages/adblocker/test/engine/engine.test.ts
@@ -1350,7 +1350,7 @@ foo.com###selector
       expect(() => FilterEngine.merge([FilterEngine.empty()])).to.throw(error);
     });
 
-    it('megers empty engines', () => {
+    it('merges empty engines', () => {
       const filters = FilterEngine.merge([
         FilterEngine.empty(),
         FilterEngine.empty(),
@@ -1407,6 +1407,15 @@ foo.com###selector
               ['b', 'b'],
             ]),
           );
+        // Check that the original engines are not modified
+
+        expect(engine1)
+          .to.have.property('lists')
+          .that.deep.equal(new Map([['a', 'a']]));
+
+        expect(engine2)
+          .to.have.property('lists')
+          .that.deep.equal(new Map([['b', 'b']]));
       });
 
       it('removes duplicates', () => {


### PR DESCRIPTION
The `FilterEngine.merge()` method has a bug, which mutates the first engine lists passed to the function.

As a result, after merging, the first engine from the list has added IDs of all lists of the engines. The iteration goes through all engines, it can be simply changed to empty `Map`.