### PR TITLE
docs: Fix build badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@
 
 <p align="center">
   <a href="https://github.com/ghostery/adblocker/actions?query=workflow%3ATests">
-    <img alt="Github Actions Build Status" src="https://img.shields.io/github/actions/workflow/status/ghostery/adblocker/tests.yml?branch=master&label=tests&style=flat-square"></a>
+    <img alt="Github Actions Build Status" src="https://img.shields.io/github/actions/workflow/status/ghostery/adblocker/tests.yml?label=tests&style=flat-square"></a>
   <a href="https://github.com/ghostery/adblocker/actions?query=workflow%3Assets">
-    <img alt="Github Actions Assets Status" src="https://img.shields.io/github/actions/workflow/status/ghostery/adblocker/assets.yml?branch=master&label=assets&style=flat-square"></a>
+    <img alt="Github Actions Assets Status" src="https://img.shields.io/github/actions/workflow/status/ghostery/adblocker/assets.yml?label=assets&style=flat-square"></a>
   <a href="https://twitter.com/acdlite/status/974390255393505280">
     <img alt="Blazing Fast" src="https://img.shields.io/badge/speed-blazing%20%F0%9F%94%A5-brightgreen.svg?style=flat-square"></a>
   <a href="https://www.npmjs.com/package/@ghostery/adblocker">

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@
 
 <p align="center">
   <a href="https://github.com/ghostery/adblocker/actions?query=workflow%3ATests">
-    <img alt="Github Actions Build Status" src="https://img.shields.io/github/actions/workflow/status/ghostery/adblocker/tests.yml?label=tests&style=flat-square"></a>
+    <img alt="Github Actions Build Status" src="https://img.shields.io/github/actions/workflow/status/ghostery/adblocker/tests.yml?branch=master&label=tests&style=flat-square"></a>
   <a href="https://github.com/ghostery/adblocker/actions?query=workflow%3Assets">
-    <img alt="Github Actions Assets Status" src="https://img.shields.io/github/actions/workflow/status/ghostery/adblocker/assets.yml?label=assets&style=flat-square"></a>
+    <img alt="Github Actions Assets Status" src="https://img.shields.io/github/actions/workflow/status/ghostery/adblocker/assets.yml?branch=master&label=assets&style=flat-square"></a>
   <a href="https://twitter.com/acdlite/status/974390255393505280">
     <img alt="Blazing Fast" src="https://img.shields.io/badge/speed-blazing%20%F0%9F%94%A5-brightgreen.svg?style=flat-square"></a>
   <a href="https://www.npmjs.com/package/@ghostery/adblocker">

--- a/bench/comparison/README.md
+++ b/bench/comparison/README.md
@@ -19,9 +19,9 @@
 
 <p align="center">
   <a href="https://github.com/ghostery/adblocker/actions?query=workflow%3ATests">
-    <img alt="Github Actions Build Status" src="https://img.shields.io/github/actions/workflow/status/ghostery/adblocker/tests.yml?branch=master&label=tests&style=flat-square"></a>
+    <img alt="Github Actions Build Status" src="https://img.shields.io/github/actions/workflow/status/ghostery/adblocker/tests.yml?label=tests&style=flat-square"></a>
   <a href="https://github.com/ghostery/adblocker/actions?query=workflow%3Assets">
-    <img alt="Github Actions Assets Status" src="https://img.shields.io/github/actions/workflow/status/ghostery/adblocker/assets.yml?branch=master&label=assets&style=flat-square"></a>
+    <img alt="Github Actions Assets Status" src="https://img.shields.io/github/actions/workflow/status/ghostery/adblocker/assets.yml?label=assets&style=flat-square"></a>
   <a href="https://twitter.com/acdlite/status/974390255393505280">
     <img alt="Blazing Fast" src="https://img.shields.io/badge/speed-blazing%20%F0%9F%94%A5-brightgreen.svg?style=flat-square"></a>
   <a href="https://www.npmjs.com/package/@ghostery/adblocker">

--- a/bench/comparison/README.md
+++ b/bench/comparison/README.md
@@ -19,9 +19,9 @@
 
 <p align="center">
   <a href="https://github.com/ghostery/adblocker/actions?query=workflow%3ATests">
-    <img alt="Github Actions Build Status" src="https://img.shields.io/github/workflow/status/ghostery/adblocker/Tests?label=tests&style=flat-square"></a>
+    <img alt="Github Actions Build Status" src="https://img.shields.io/github/actions/workflow/status/ghostery/adblocker/tests.yml?branch=master&label=tests&style=flat-square"></a>
   <a href="https://github.com/ghostery/adblocker/actions?query=workflow%3Assets">
-    <img alt="Github Actions Assets Status" src="https://img.shields.io/github/workflow/status/ghostery/adblocker/Assets?label=assets&style=flat-square"></a>
+    <img alt="Github Actions Assets Status" src="https://img.shields.io/github/actions/workflow/status/ghostery/adblocker/assets.yml?branch=master&label=assets&style=flat-square"></a>
   <a href="https://twitter.com/acdlite/status/974390255393505280">
     <img alt="Blazing Fast" src="https://img.shields.io/badge/speed-blazing%20%F0%9F%94%A5-brightgreen.svg?style=flat-square"></a>
   <a href="https://www.npmjs.com/package/@ghostery/adblocker">

--- a/packages/adblocker-content/README.md
+++ b/packages/adblocker-content/README.md
@@ -19,9 +19,9 @@
 
 <p align="center">
   <a href="https://github.com/ghostery/adblocker/actions?query=workflow%3ATests">
-    <img alt="Github Actions Build Status" src="https://img.shields.io/github/actions/workflow/status/ghostery/adblocker/tests.yml?branch=master&label=tests&style=flat-square"></a>
+    <img alt="Github Actions Build Status" src="https://img.shields.io/github/actions/workflow/status/ghostery/adblocker/tests.yml?label=tests&style=flat-square"></a>
   <a href="https://github.com/ghostery/adblocker/actions?query=workflow%3Assets">
-    <img alt="Github Actions Assets Status" src="https://img.shields.io/github/actions/workflow/status/ghostery/adblocker/assets.yml?branch=master&label=assets&style=flat-square"></a>
+    <img alt="Github Actions Assets Status" src="https://img.shields.io/github/actions/workflow/status/ghostery/adblocker/assets.yml?label=assets&style=flat-square"></a>
   <a href="https://twitter.com/acdlite/status/974390255393505280">
     <img alt="Blazing Fast" src="https://img.shields.io/badge/speed-blazing%20%F0%9F%94%A5-brightgreen.svg?style=flat-square"></a>
   <a href="https://www.npmjs.com/package/@ghostery/adblocker">

--- a/packages/adblocker-content/README.md
+++ b/packages/adblocker-content/README.md
@@ -19,9 +19,9 @@
 
 <p align="center">
   <a href="https://github.com/ghostery/adblocker/actions?query=workflow%3ATests">
-    <img alt="Github Actions Build Status" src="https://img.shields.io/github/workflow/status/ghostery/adblocker/Tests?label=tests&style=flat-square"></a>
+    <img alt="Github Actions Build Status" src="https://img.shields.io/github/actions/workflow/status/ghostery/adblocker/tests.yml?branch=master&label=tests&style=flat-square"></a>
   <a href="https://github.com/ghostery/adblocker/actions?query=workflow%3Assets">
-    <img alt="Github Actions Assets Status" src="https://img.shields.io/github/workflow/status/ghostery/adblocker/Assets?label=assets&style=flat-square"></a>
+    <img alt="Github Actions Assets Status" src="https://img.shields.io/github/actions/workflow/status/ghostery/adblocker/assets.yml?branch=master&label=assets&style=flat-square"></a>
   <a href="https://twitter.com/acdlite/status/974390255393505280">
     <img alt="Blazing Fast" src="https://img.shields.io/badge/speed-blazing%20%F0%9F%94%A5-brightgreen.svg?style=flat-square"></a>
   <a href="https://www.npmjs.com/package/@ghostery/adblocker">

--- a/packages/adblocker-electron-example/README.md
+++ b/packages/adblocker-electron-example/README.md
@@ -19,9 +19,9 @@
 
 <p align="center">
   <a href="https://github.com/ghostery/adblocker/actions?query=workflow%3ATests">
-    <img alt="Github Actions Build Status" src="https://img.shields.io/github/actions/workflow/status/ghostery/adblocker/tests.yml?branch=master&label=tests&style=flat-square"></a>
+    <img alt="Github Actions Build Status" src="https://img.shields.io/github/actions/workflow/status/ghostery/adblocker/tests.yml?label=tests&style=flat-square"></a>
   <a href="https://github.com/ghostery/adblocker/actions?query=workflow%3Assets">
-    <img alt="Github Actions Assets Status" src="https://img.shields.io/github/actions/workflow/status/ghostery/adblocker/assets.yml?branch=master&label=assets&style=flat-square"></a>
+    <img alt="Github Actions Assets Status" src="https://img.shields.io/github/actions/workflow/status/ghostery/adblocker/assets.yml?label=assets&style=flat-square"></a>
   <a href="https://twitter.com/acdlite/status/974390255393505280">
     <img alt="Blazing Fast" src="https://img.shields.io/badge/speed-blazing%20%F0%9F%94%A5-brightgreen.svg?style=flat-square"></a>
   <a href="https://www.npmjs.com/package/@ghostery/adblocker">

--- a/packages/adblocker-electron-example/README.md
+++ b/packages/adblocker-electron-example/README.md
@@ -19,9 +19,9 @@
 
 <p align="center">
   <a href="https://github.com/ghostery/adblocker/actions?query=workflow%3ATests">
-    <img alt="Github Actions Build Status" src="https://img.shields.io/github/workflow/status/ghostery/adblocker/Tests?label=tests&style=flat-square"></a>
+    <img alt="Github Actions Build Status" src="https://img.shields.io/github/actions/workflow/status/ghostery/adblocker/tests.yml?branch=master&label=tests&style=flat-square"></a>
   <a href="https://github.com/ghostery/adblocker/actions?query=workflow%3Assets">
-    <img alt="Github Actions Assets Status" src="https://img.shields.io/github/workflow/status/ghostery/adblocker/Assets?label=assets&style=flat-square"></a>
+    <img alt="Github Actions Assets Status" src="https://img.shields.io/github/actions/workflow/status/ghostery/adblocker/assets.yml?branch=master&label=assets&style=flat-square"></a>
   <a href="https://twitter.com/acdlite/status/974390255393505280">
     <img alt="Blazing Fast" src="https://img.shields.io/badge/speed-blazing%20%F0%9F%94%A5-brightgreen.svg?style=flat-square"></a>
   <a href="https://www.npmjs.com/package/@ghostery/adblocker">

--- a/packages/adblocker-electron-preload/README.md
+++ b/packages/adblocker-electron-preload/README.md
@@ -19,9 +19,9 @@
 
 <p align="center">
   <a href="https://github.com/ghostery/adblocker/actions?query=workflow%3ATests">
-    <img alt="Github Actions Build Status" src="https://img.shields.io/github/actions/workflow/status/ghostery/adblocker/tests.yml?branch=master&label=tests&style=flat-square"></a>
+    <img alt="Github Actions Build Status" src="https://img.shields.io/github/actions/workflow/status/ghostery/adblocker/tests.yml?label=tests&style=flat-square"></a>
   <a href="https://github.com/ghostery/adblocker/actions?query=workflow%3Assets">
-    <img alt="Github Actions Assets Status" src="https://img.shields.io/github/actions/workflow/status/ghostery/adblocker/assets.yml?branch=master&label=assets&style=flat-square"></a>
+    <img alt="Github Actions Assets Status" src="https://img.shields.io/github/actions/workflow/status/ghostery/adblocker/assets.yml?label=assets&style=flat-square"></a>
   <a href="https://twitter.com/acdlite/status/974390255393505280">
     <img alt="Blazing Fast" src="https://img.shields.io/badge/speed-blazing%20%F0%9F%94%A5-brightgreen.svg?style=flat-square"></a>
   <a href="https://www.npmjs.com/package/@ghostery/adblocker">

--- a/packages/adblocker-electron-preload/README.md
+++ b/packages/adblocker-electron-preload/README.md
@@ -19,9 +19,9 @@
 
 <p align="center">
   <a href="https://github.com/ghostery/adblocker/actions?query=workflow%3ATests">
-    <img alt="Github Actions Build Status" src="https://img.shields.io/github/workflow/status/ghostery/adblocker/Tests?label=tests&style=flat-square"></a>
+    <img alt="Github Actions Build Status" src="https://img.shields.io/github/actions/workflow/status/ghostery/adblocker/tests.yml?branch=master&label=tests&style=flat-square"></a>
   <a href="https://github.com/ghostery/adblocker/actions?query=workflow%3Assets">
-    <img alt="Github Actions Assets Status" src="https://img.shields.io/github/workflow/status/ghostery/adblocker/Assets?label=assets&style=flat-square"></a>
+    <img alt="Github Actions Assets Status" src="https://img.shields.io/github/actions/workflow/status/ghostery/adblocker/assets.yml?branch=master&label=assets&style=flat-square"></a>
   <a href="https://twitter.com/acdlite/status/974390255393505280">
     <img alt="Blazing Fast" src="https://img.shields.io/badge/speed-blazing%20%F0%9F%94%A5-brightgreen.svg?style=flat-square"></a>
   <a href="https://www.npmjs.com/package/@ghostery/adblocker">

--- a/packages/adblocker-electron/README.md
+++ b/packages/adblocker-electron/README.md
@@ -19,9 +19,9 @@
 
 <p align="center">
   <a href="https://github.com/ghostery/adblocker/actions?query=workflow%3ATests">
-    <img alt="Github Actions Build Status" src="https://img.shields.io/github/actions/workflow/status/ghostery/adblocker/tests.yml?branch=master&label=tests&style=flat-square"></a>
+    <img alt="Github Actions Build Status" src="https://img.shields.io/github/actions/workflow/status/ghostery/adblocker/tests.yml?label=tests&style=flat-square"></a>
   <a href="https://github.com/ghostery/adblocker/actions?query=workflow%3Assets">
-    <img alt="Github Actions Assets Status" src="https://img.shields.io/github/actions/workflow/status/ghostery/adblocker/assets.yml?branch=master&label=assets&style=flat-square"></a>
+    <img alt="Github Actions Assets Status" src="https://img.shields.io/github/actions/workflow/status/ghostery/adblocker/assets.yml?label=assets&style=flat-square"></a>
   <a href="https://twitter.com/acdlite/status/974390255393505280">
     <img alt="Blazing Fast" src="https://img.shields.io/badge/speed-blazing%20%F0%9F%94%A5-brightgreen.svg?style=flat-square"></a>
   <a href="https://www.npmjs.com/package/@ghostery/adblocker">

--- a/packages/adblocker-electron/README.md
+++ b/packages/adblocker-electron/README.md
@@ -19,9 +19,9 @@
 
 <p align="center">
   <a href="https://github.com/ghostery/adblocker/actions?query=workflow%3ATests">
-    <img alt="Github Actions Build Status" src="https://img.shields.io/github/workflow/status/ghostery/adblocker/Tests?label=tests&style=flat-square"></a>
+    <img alt="Github Actions Build Status" src="https://img.shields.io/github/actions/workflow/status/ghostery/adblocker/tests.yml?branch=master&label=tests&style=flat-square"></a>
   <a href="https://github.com/ghostery/adblocker/actions?query=workflow%3Assets">
-    <img alt="Github Actions Assets Status" src="https://img.shields.io/github/workflow/status/ghostery/adblocker/Assets?label=assets&style=flat-square"></a>
+    <img alt="Github Actions Assets Status" src="https://img.shields.io/github/actions/workflow/status/ghostery/adblocker/assets.yml?branch=master&label=assets&style=flat-square"></a>
   <a href="https://twitter.com/acdlite/status/974390255393505280">
     <img alt="Blazing Fast" src="https://img.shields.io/badge/speed-blazing%20%F0%9F%94%A5-brightgreen.svg?style=flat-square"></a>
   <a href="https://www.npmjs.com/package/@ghostery/adblocker">

--- a/packages/adblocker-extended-selectors/README.md
+++ b/packages/adblocker-extended-selectors/README.md
@@ -19,9 +19,9 @@
 
 <p align="center">
   <a href="https://github.com/ghostery/adblocker/actions?query=workflow%3ATests">
-    <img alt="Github Actions Build Status" src="https://img.shields.io/github/actions/workflow/status/ghostery/adblocker/tests.yml?branch=master&label=tests&style=flat-square"></a>
+    <img alt="Github Actions Build Status" src="https://img.shields.io/github/actions/workflow/status/ghostery/adblocker/tests.yml?label=tests&style=flat-square"></a>
   <a href="https://github.com/ghostery/adblocker/actions?query=workflow%3Assets">
-    <img alt="Github Actions Assets Status" src="https://img.shields.io/github/actions/workflow/status/ghostery/adblocker/assets.yml?branch=master&label=assets&style=flat-square"></a>
+    <img alt="Github Actions Assets Status" src="https://img.shields.io/github/actions/workflow/status/ghostery/adblocker/assets.yml?label=assets&style=flat-square"></a>
   <a href="https://twitter.com/acdlite/status/974390255393505280">
     <img alt="Blazing Fast" src="https://img.shields.io/badge/speed-blazing%20%F0%9F%94%A5-brightgreen.svg?style=flat-square"></a>
   <a href="https://www.npmjs.com/package/@ghostery/adblocker">

--- a/packages/adblocker-extended-selectors/README.md
+++ b/packages/adblocker-extended-selectors/README.md
@@ -19,9 +19,9 @@
 
 <p align="center">
   <a href="https://github.com/ghostery/adblocker/actions?query=workflow%3ATests">
-    <img alt="Github Actions Build Status" src="https://img.shields.io/github/workflow/status/ghostery/adblocker/Tests?label=tests&style=flat-square"></a>
+    <img alt="Github Actions Build Status" src="https://img.shields.io/github/actions/workflow/status/ghostery/adblocker/tests.yml?branch=master&label=tests&style=flat-square"></a>
   <a href="https://github.com/ghostery/adblocker/actions?query=workflow%3Assets">
-    <img alt="Github Actions Assets Status" src="https://img.shields.io/github/workflow/status/ghostery/adblocker/Assets?label=assets&style=flat-square"></a>
+    <img alt="Github Actions Assets Status" src="https://img.shields.io/github/actions/workflow/status/ghostery/adblocker/assets.yml?branch=master&label=assets&style=flat-square"></a>
   <a href="https://twitter.com/acdlite/status/974390255393505280">
     <img alt="Blazing Fast" src="https://img.shields.io/badge/speed-blazing%20%F0%9F%94%A5-brightgreen.svg?style=flat-square"></a>
   <a href="https://www.npmjs.com/package/@ghostery/adblocker">

--- a/packages/adblocker-playwright/README.md
+++ b/packages/adblocker-playwright/README.md
@@ -19,9 +19,9 @@
 
 <p align="center">
   <a href="https://github.com/ghostery/adblocker/actions?query=workflow%3ATests">
-    <img alt="Github Actions Build Status" src="https://img.shields.io/github/actions/workflow/status/ghostery/adblocker/tests.yml?branch=master&label=tests&style=flat-square"></a>
+    <img alt="Github Actions Build Status" src="https://img.shields.io/github/actions/workflow/status/ghostery/adblocker/tests.yml?label=tests&style=flat-square"></a>
   <a href="https://github.com/ghostery/adblocker/actions?query=workflow%3Assets">
-    <img alt="Github Actions Assets Status" src="https://img.shields.io/github/actions/workflow/status/ghostery/adblocker/assets.yml?branch=master&label=assets&style=flat-square"></a>
+    <img alt="Github Actions Assets Status" src="https://img.shields.io/github/actions/workflow/status/ghostery/adblocker/assets.yml?label=assets&style=flat-square"></a>
   <a href="https://twitter.com/acdlite/status/974390255393505280">
     <img alt="Blazing Fast" src="https://img.shields.io/badge/speed-blazing%20%F0%9F%94%A5-brightgreen.svg?style=flat-square"></a>
   <a href="https://www.npmjs.com/package/@ghostery/adblocker">

--- a/packages/adblocker-playwright/README.md
+++ b/packages/adblocker-playwright/README.md
@@ -19,9 +19,9 @@
 
 <p align="center">
   <a href="https://github.com/ghostery/adblocker/actions?query=workflow%3ATests">
-    <img alt="Github Actions Build Status" src="https://img.shields.io/github/workflow/status/ghostery/adblocker/Tests?label=tests&style=flat-square"></a>
+    <img alt="Github Actions Build Status" src="https://img.shields.io/github/actions/workflow/status/ghostery/adblocker/tests.yml?branch=master&label=tests&style=flat-square"></a>
   <a href="https://github.com/ghostery/adblocker/actions?query=workflow%3Assets">
-    <img alt="Github Actions Assets Status" src="https://img.shields.io/github/workflow/status/ghostery/adblocker/Assets?label=assets&style=flat-square"></a>
+    <img alt="Github Actions Assets Status" src="https://img.shields.io/github/actions/workflow/status/ghostery/adblocker/assets.yml?branch=master&label=assets&style=flat-square"></a>
   <a href="https://twitter.com/acdlite/status/974390255393505280">
     <img alt="Blazing Fast" src="https://img.shields.io/badge/speed-blazing%20%F0%9F%94%A5-brightgreen.svg?style=flat-square"></a>
   <a href="https://www.npmjs.com/package/@ghostery/adblocker">

--- a/packages/adblocker-puppeteer-example/README.md
+++ b/packages/adblocker-puppeteer-example/README.md
@@ -19,9 +19,9 @@
 
 <p align="center">
   <a href="https://github.com/ghostery/adblocker/actions?query=workflow%3ATests">
-    <img alt="Github Actions Build Status" src="https://img.shields.io/github/actions/workflow/status/ghostery/adblocker/tests.yml?branch=master&label=tests&style=flat-square"></a>
+    <img alt="Github Actions Build Status" src="https://img.shields.io/github/actions/workflow/status/ghostery/adblocker/tests.yml?label=tests&style=flat-square"></a>
   <a href="https://github.com/ghostery/adblocker/actions?query=workflow%3Assets">
-    <img alt="Github Actions Assets Status" src="https://img.shields.io/github/actions/workflow/status/ghostery/adblocker/assets.yml?branch=master&label=assets&style=flat-square"></a>
+    <img alt="Github Actions Assets Status" src="https://img.shields.io/github/actions/workflow/status/ghostery/adblocker/assets.yml?label=assets&style=flat-square"></a>
   <a href="https://twitter.com/acdlite/status/974390255393505280">
     <img alt="Blazing Fast" src="https://img.shields.io/badge/speed-blazing%20%F0%9F%94%A5-brightgreen.svg?style=flat-square"></a>
   <a href="https://www.npmjs.com/package/@ghostery/adblocker">

--- a/packages/adblocker-puppeteer-example/README.md
+++ b/packages/adblocker-puppeteer-example/README.md
@@ -19,9 +19,9 @@
 
 <p align="center">
   <a href="https://github.com/ghostery/adblocker/actions?query=workflow%3ATests">
-    <img alt="Github Actions Build Status" src="https://img.shields.io/github/workflow/status/ghostery/adblocker/Tests?label=tests&style=flat-square"></a>
+    <img alt="Github Actions Build Status" src="https://img.shields.io/github/actions/workflow/status/ghostery/adblocker/tests.yml?branch=master&label=tests&style=flat-square"></a>
   <a href="https://github.com/ghostery/adblocker/actions?query=workflow%3Assets">
-    <img alt="Github Actions Assets Status" src="https://img.shields.io/github/workflow/status/ghostery/adblocker/Assets?label=assets&style=flat-square"></a>
+    <img alt="Github Actions Assets Status" src="https://img.shields.io/github/actions/workflow/status/ghostery/adblocker/assets.yml?branch=master&label=assets&style=flat-square"></a>
   <a href="https://twitter.com/acdlite/status/974390255393505280">
     <img alt="Blazing Fast" src="https://img.shields.io/badge/speed-blazing%20%F0%9F%94%A5-brightgreen.svg?style=flat-square"></a>
   <a href="https://www.npmjs.com/package/@ghostery/adblocker">

--- a/packages/adblocker-puppeteer/README.md
+++ b/packages/adblocker-puppeteer/README.md
@@ -19,9 +19,9 @@
 
 <p align="center">
   <a href="https://github.com/ghostery/adblocker/actions?query=workflow%3ATests">
-    <img alt="Github Actions Build Status" src="https://img.shields.io/github/actions/workflow/status/ghostery/adblocker/tests.yml?branch=master&label=tests&style=flat-square"></a>
+    <img alt="Github Actions Build Status" src="https://img.shields.io/github/actions/workflow/status/ghostery/adblocker/tests.yml?label=tests&style=flat-square"></a>
   <a href="https://github.com/ghostery/adblocker/actions?query=workflow%3Assets">
-    <img alt="Github Actions Assets Status" src="https://img.shields.io/github/actions/workflow/status/ghostery/adblocker/assets.yml?branch=master&label=assets&style=flat-square"></a>
+    <img alt="Github Actions Assets Status" src="https://img.shields.io/github/actions/workflow/status/ghostery/adblocker/assets.yml?label=assets&style=flat-square"></a>
   <a href="https://twitter.com/acdlite/status/974390255393505280">
     <img alt="Blazing Fast" src="https://img.shields.io/badge/speed-blazing%20%F0%9F%94%A5-brightgreen.svg?style=flat-square"></a>
   <a href="https://www.npmjs.com/package/@ghostery/adblocker">

--- a/packages/adblocker-puppeteer/README.md
+++ b/packages/adblocker-puppeteer/README.md
@@ -19,9 +19,9 @@
 
 <p align="center">
   <a href="https://github.com/ghostery/adblocker/actions?query=workflow%3ATests">
-    <img alt="Github Actions Build Status" src="https://img.shields.io/github/workflow/status/ghostery/adblocker/Tests?label=tests&style=flat-square"></a>
+    <img alt="Github Actions Build Status" src="https://img.shields.io/github/actions/workflow/status/ghostery/adblocker/tests.yml?branch=master&label=tests&style=flat-square"></a>
   <a href="https://github.com/ghostery/adblocker/actions?query=workflow%3Assets">
-    <img alt="Github Actions Assets Status" src="https://img.shields.io/github/workflow/status/ghostery/adblocker/Assets?label=assets&style=flat-square"></a>
+    <img alt="Github Actions Assets Status" src="https://img.shields.io/github/actions/workflow/status/ghostery/adblocker/assets.yml?branch=master&label=assets&style=flat-square"></a>
   <a href="https://twitter.com/acdlite/status/974390255393505280">
     <img alt="Blazing Fast" src="https://img.shields.io/badge/speed-blazing%20%F0%9F%94%A5-brightgreen.svg?style=flat-square"></a>
   <a href="https://www.npmjs.com/package/@ghostery/adblocker">

--- a/packages/adblocker-webextension/README.md
+++ b/packages/adblocker-webextension/README.md
@@ -19,9 +19,9 @@
 
 <p align="center">
   <a href="https://github.com/ghostery/adblocker/actions?query=workflow%3ATests">
-    <img alt="Github Actions Build Status" src="https://img.shields.io/github/actions/workflow/status/ghostery/adblocker/tests.yml?branch=master&label=tests&style=flat-square"></a>
+    <img alt="Github Actions Build Status" src="https://img.shields.io/github/actions/workflow/status/ghostery/adblocker/tests.yml?label=tests&style=flat-square"></a>
   <a href="https://github.com/ghostery/adblocker/actions?query=workflow%3Assets">
-    <img alt="Github Actions Assets Status" src="https://img.shields.io/github/actions/workflow/status/ghostery/adblocker/assets.yml?branch=master&label=assets&style=flat-square"></a>
+    <img alt="Github Actions Assets Status" src="https://img.shields.io/github/actions/workflow/status/ghostery/adblocker/assets.yml?label=assets&style=flat-square"></a>
   <a href="https://twitter.com/acdlite/status/974390255393505280">
     <img alt="Blazing Fast" src="https://img.shields.io/badge/speed-blazing%20%F0%9F%94%A5-brightgreen.svg?style=flat-square"></a>
   <a href="https://www.npmjs.com/package/@ghostery/adblocker">

--- a/packages/adblocker-webextension/README.md
+++ b/packages/adblocker-webextension/README.md
@@ -19,9 +19,9 @@
 
 <p align="center">
   <a href="https://github.com/ghostery/adblocker/actions?query=workflow%3ATests">
-    <img alt="Github Actions Build Status" src="https://img.shields.io/github/workflow/status/ghostery/adblocker/Tests?label=tests&style=flat-square"></a>
+    <img alt="Github Actions Build Status" src="https://img.shields.io/github/actions/workflow/status/ghostery/adblocker/tests.yml?branch=master&label=tests&style=flat-square"></a>
   <a href="https://github.com/ghostery/adblocker/actions?query=workflow%3Assets">
-    <img alt="Github Actions Assets Status" src="https://img.shields.io/github/workflow/status/ghostery/adblocker/Assets?label=assets&style=flat-square"></a>
+    <img alt="Github Actions Assets Status" src="https://img.shields.io/github/actions/workflow/status/ghostery/adblocker/assets.yml?branch=master&label=assets&style=flat-square"></a>
   <a href="https://twitter.com/acdlite/status/974390255393505280">
     <img alt="Blazing Fast" src="https://img.shields.io/badge/speed-blazing%20%F0%9F%94%A5-brightgreen.svg?style=flat-square"></a>
   <a href="https://www.npmjs.com/package/@ghostery/adblocker">

--- a/packages/adblocker/README.md
+++ b/packages/adblocker/README.md
@@ -19,9 +19,9 @@
 
 <p align="center">
   <a href="https://github.com/ghostery/adblocker/actions?query=workflow%3ATests">
-    <img alt="Github Actions Build Status" src="https://img.shields.io/github/actions/workflow/status/ghostery/adblocker/tests.yml?branch=master&label=tests&style=flat-square"></a>
+    <img alt="Github Actions Build Status" src="https://img.shields.io/github/actions/workflow/status/ghostery/adblocker/tests.yml?label=tests&style=flat-square"></a>
   <a href="https://github.com/ghostery/adblocker/actions?query=workflow%3Assets">
-    <img alt="Github Actions Assets Status" src="https://img.shields.io/github/actions/workflow/status/ghostery/adblocker/assets.yml?branch=master&label=assets&style=flat-square"></a>
+    <img alt="Github Actions Assets Status" src="https://img.shields.io/github/actions/workflow/status/ghostery/adblocker/assets.yml?label=assets&style=flat-square"></a>
   <a href="https://twitter.com/acdlite/status/974390255393505280">
     <img alt="Blazing Fast" src="https://img.shields.io/badge/speed-blazing%20%F0%9F%94%A5-brightgreen.svg?style=flat-square"></a>
   <a href="https://www.npmjs.com/package/@ghostery/adblocker">

--- a/packages/adblocker/README.md
+++ b/packages/adblocker/README.md
@@ -19,9 +19,9 @@
 
 <p align="center">
   <a href="https://github.com/ghostery/adblocker/actions?query=workflow%3ATests">
-    <img alt="Github Actions Build Status" src="https://img.shields.io/github/workflow/status/ghostery/adblocker/Tests?label=tests&style=flat-square"></a>
+    <img alt="Github Actions Build Status" src="https://img.shields.io/github/actions/workflow/status/ghostery/adblocker/tests.yml?branch=master&label=tests&style=flat-square"></a>
   <a href="https://github.com/ghostery/adblocker/actions?query=workflow%3Assets">
-    <img alt="Github Actions Assets Status" src="https://img.shields.io/github/workflow/status/ghostery/adblocker/Assets?label=assets&style=flat-square"></a>
+    <img alt="Github Actions Assets Status" src="https://img.shields.io/github/actions/workflow/status/ghostery/adblocker/assets.yml?branch=master&label=assets&style=flat-square"></a>
   <a href="https://twitter.com/acdlite/status/974390255393505280">
     <img alt="Blazing Fast" src="https://img.shields.io/badge/speed-blazing%20%F0%9F%94%A5-brightgreen.svg?style=flat-square"></a>
   <a href="https://www.npmjs.com/package/@ghostery/adblocker">


### PR DESCRIPTION
Fix build badges in READMEs. See https://github.com/badges/shields/issues/8671

- Current: <img alt="Github Actions Build Status" src="https://img.shields.io/github/workflow/status/ghostery/adblocker/Tests?label=tests&style=flat-square"> <img alt="Github Actions Assets Status" src="https://img.shields.io/github/workflow/status/ghostery/adblocker/Assets?label=assets&style=flat-square">
- Futur: <img alt="Github Actions Build Status" src="https://img.shields.io/github/actions/workflow/status/ghostery/adblocker/tests.yml?label=tests&style=flat-square"> <img alt="Github Actions Assets Status" src="https://img.shields.io/github/actions/workflow/status/ghostery/adblocker/assets.yml?label=assets&style=flat-square">