### PR TITLE
fix: unexported global namespaces `chrome` and `browser`

### DIFF
--- a/packages/adblocker/package.json
+++ b/packages/adblocker/package.json
@@ -121,8 +121,6 @@
     "@remusao/guess-url-type": "^1.3.0",
     "@remusao/small": "^1.2.1",
     "@remusao/smaz": "^1.9.1",
-    "@types/chrome": "^0.0.280",
-    "@types/firefox-webext-browser": "^120.0.0",
     "tldts-experimental": "^6.0.14"
   }
 }

--- a/packages/adblocker/src/request.ts
+++ b/packages/adblocker/src/request.ts
@@ -70,11 +70,44 @@ export type PlaywrightRequestType =
   | 'websocket'
   | 'xhr';
 
-// From: https://developer.chrome.com/extensions/webRequest#type-ResourceType
-export type WebRequestTypeChrome = chrome.webRequest.ResourceType;
+// From: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/chrome/index.d.ts#L11989
+export type WebRequestTypeChrome =
+  | 'main_frame'
+  | 'sub_frame'
+  | 'stylesheet'
+  | 'script'
+  | 'image'
+  | 'font'
+  | 'object'
+  | 'xmlhttprequest'
+  | 'ping'
+  | 'csp_report'
+  | 'media'
+  | 'websocket'
+  | 'other';
 
-// From: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/ResourceType#Type
-export type WebRequestTypeFirefox = browser.webRequest.ResourceType;
+// From: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/firefox-webext-browser/index.d.ts#L2126
+export type WebRequestTypeFirefox =
+  | 'main_frame'
+  | 'sub_frame'
+  | 'stylesheet'
+  | 'script'
+  | 'image'
+  | 'object'
+  | 'object_subrequest'
+  | 'xmlhttprequest'
+  | 'xslt'
+  | 'ping'
+  | 'beacon'
+  | 'xml_dtd'
+  | 'font'
+  | 'media'
+  | 'websocket'
+  | 'csp_report'
+  | 'imageset'
+  | 'web_manifest'
+  | 'speculative'
+  | 'other';
 
 // The set of WebRequest types is the union of both Firefox and Chrome
 export type WebRequestType = WebRequestTypeChrome | WebRequestTypeFirefox;

--- a/yarn.lock
+++ b/yarn.lock
@@ -937,8 +937,6 @@ __metadata:
     "@remusao/smaz-generate": "npm:^1.9.1"
     "@rollup/plugin-terser": "npm:^0.4.4"
     "@types/chai": "npm:^5.0.0"
-    "@types/chrome": "npm:^0.0.280"
-    "@types/firefox-webext-browser": "npm:^120.0.0"
     "@types/mocha": "npm:^10.0.1"
     "@types/node": "npm:^22.0.2"
     axios: "npm:^1.7.2"
@@ -2405,13 +2403,6 @@ __metadata:
   version: 0.0.33
   resolution: "@types/filewriter@npm:0.0.33"
   checksum: 10/495a4bb424c27eda967fe9ac3b8f7b781e6b3f9ce59403a991590cb1073022f9c5383d3c7d808ef6956b785550c36664c4fcd502dc0baf69e340bd481171e0ca
-  languageName: node
-  linkType: hard
-
-"@types/firefox-webext-browser@npm:^120.0.0":
-  version: 120.0.4
-  resolution: "@types/firefox-webext-browser@npm:120.0.4"
-  checksum: 10/43bf4e2457764f74e803bcd80167d15e0e9d85108262991860b7ece92ca03e447100fa536ca49baf3cc8e96b3a95464c3de2719cbc2671a356e1efc5b4564cf9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
fixes https://github.com/ghostery/adblocker/issues/4120