### PR TITLE
feat: dynamic preprocessor identifiers

### DIFF
--- a/packages/adblocker/src/preprocessor.ts
+++ b/packages/adblocker/src/preprocessor.ts
@@ -85,7 +85,7 @@ const isOperator = (token: string) => Object.prototype.hasOwnProperty.call(prece
 
 const testDynamicIdentifier = (identifier: string): boolean => {
   const separatorIndex = identifier.lastIndexOf('_');
-  const cmd = identifier.slice(15 /* '__ghostery_eval_'.length */, separatorIndex);
+  const cmd = identifier.slice(16 /* '__ghostery_eval_'.length */, separatorIndex);
   const arg = identifier.slice(separatorIndex + 1);
 
   if (cmd === 'engine_version_geq') {

--- a/packages/adblocker/src/preprocessor.ts
+++ b/packages/adblocker/src/preprocessor.ts
@@ -84,10 +84,8 @@ const precedence: Record<string, number> = {
 const isOperator = (token: string) => Object.prototype.hasOwnProperty.call(precedence, token);
 
 const testDynamicIdentifier = (identifier: string): boolean => {
-  identifier = identifier.slice(15 /* '__ghostery_eval_'.length */);
-
   const separatorIndex = identifier.lastIndexOf('_');
-  const cmd = identifier.slice(0, separatorIndex);
+  const cmd = identifier.slice(15 /* '__ghostery_eval_'.length */, separatorIndex);
   const arg = identifier.slice(separatorIndex + 1);
 
   if (cmd === 'engine_version_geq') {


### PR DESCRIPTION
This adds a capability of runtime evaluated preprocessor identifiers while keeping backward compatibility and not breaking existing syntaxes. With this feature, we're able to have a fine grained control for filter distribution similar to browser feature flags.

However, we should limit the use of these dynamic identifiers not to underestimate other components like config and product-level AB feature control. For an instance, deciding a criteria for AB testing at the library level doesn't make sense.