### PR TITLE
packages: adblocker-electron: conditionally enable `webRequest` handlers

### DIFF
--- a/packages/adblocker-electron-example/src/index.ts
+++ b/packages/adblocker-electron-example/src/index.ts
@@ -39,7 +39,15 @@ async function createWindow() {
     },
   );
 
-  blocker.enableBlockingInSession(mainWindow.webContents.session);
+  blocker.enableBlockingInSession(mainWindow.webContents.session, false);
+  mainWindow.webContents.session.webRequest.onHeadersReceived(
+    { urls: ['<all_urls>'] },
+    blocker.onHeadersReceived,
+  );
+  mainWindow.webContents.session.webRequest.onBeforeRequest(
+    { urls: ['<all_urls>'] },
+    blocker.onBeforeRequest,
+  );
 
   blocker.on('request-blocked', (request: Request) => {
     console.log('blocked', request.tabId, request.url);


### PR DESCRIPTION
We make heavy use of the `webRequest` APIs in our application, but the `@ghostery/adblocker-electron` package completely takes over the `onHeadersReceived` and `onBeforeRequest` handlers without providing an escape hatch, which makes it difficult for us to use the library.

This patch provides a way for users to manually drive the adblocking process from outside the `@ghostery/adblocker-electron` dependency.