### PR TITLE
feat: build stylesheet with supported extended selectors

### DIFF
--- a/packages/adblocker-extended-selectors/src/extended.ts
+++ b/packages/adblocker-extended-selectors/src/extended.ts
@@ -7,6 +7,7 @@
  */
 
 import { tokenize, RECURSIVE_PSEUDO_CLASSES } from './parse.js';
+import { Atoms } from './types.js';
 
 export const EXTENDED_PSEUDO_CLASSES = new Set([
   // '-abp-contains',
@@ -136,4 +137,29 @@ export function classifySelector(selector: string): SelectorType {
   }
 
   return SelectorType.Normal;
+}
+
+export function getExtendedPseudoClasses(selector: string): Set<string> {
+  const extendedSelectors = new Set<string>();
+
+  if (selector.indexOf(':') === -1) {
+    return extendedSelectors;
+  }
+
+  const tokens: Atoms = [...tokenize(selector)];
+
+  while (tokens.length !== 0) {
+    const token = tokens.shift()!;
+
+    if (token.type === 'pseudo-class') {
+      if (EXTENDED_PSEUDO_CLASSES.has(token.name) === true) {
+        extendedSelectors.add(token.name);
+      }
+      if (token.argument !== undefined && RECURSIVE_PSEUDO_CLASSES.has(token.name) === true) {
+        tokens.push(...tokenize(token.argument));
+      }
+    }
+  }
+
+  return extendedSelectors;
 }

--- a/packages/adblocker-extended-selectors/src/index.ts
+++ b/packages/adblocker-extended-selectors/src/index.ts
@@ -15,4 +15,5 @@ export {
   PSEUDO_ELEMENTS,
   SelectorType,
   classifySelector,
+  getExtendedPseudoClasses,
 } from './extended.js';

--- a/packages/adblocker/src/engine/engine.ts
+++ b/packages/adblocker/src/engine/engine.ts
@@ -990,6 +990,8 @@ export default class FilterEngine extends EventEmitter<EngineEventHandlers> {
     getRulesFromDOM = true,
     getRulesFromHostname = true,
 
+    // Other information
+    experimentalPseudoClasses = ['has'],
     hidingStyle,
     callerContext,
   }: {
@@ -1007,6 +1009,9 @@ export default class FilterEngine extends EventEmitter<EngineEventHandlers> {
     getRulesFromDOM?: boolean;
     getRulesFromHostname?: boolean;
 
+    // If set, outputs a separate css block with specified experimental selectors.
+    // This argument has a higher priority than `getExtendedRules`.
+    experimentalPseudoClasses?: string[] | undefined;
     hidingStyle?: string | undefined;
     callerContext?: any | undefined;
   }): IMessageFromBackground {
@@ -1122,7 +1127,13 @@ export default class FilterEngine extends EventEmitter<EngineEventHandlers> {
             applied = true;
           }
         } else if (filter.isExtended()) {
-          if (getExtendedRules === true) {
+          if (
+            experimentalPseudoClasses.length !== 0 &&
+            filter.hasUnsupportedExtendedPseudoClass(experimentalPseudoClasses) === false
+          ) {
+            styleFilters.push(filter);
+            applied = true;
+          } else if (getExtendedRules === true) {
             extendedFilters.push(filter);
             applied = true;
           }

--- a/packages/adblocker/src/filters/cosmetic.ts
+++ b/packages/adblocker/src/filters/cosmetic.ts
@@ -11,6 +11,7 @@ import {
   classifySelector,
   SelectorType,
   parse as parseCssSelector,
+  getExtendedPseudoClasses,
 } from '@ghostery/adblocker-extended-selectors';
 
 import { Domains } from '../engine/domains.js';
@@ -425,6 +426,7 @@ export default class CosmeticFilter implements IFilter {
 
   private id: number | undefined;
   private scriptletDetails: { name: string; args: string[] } | undefined;
+  private extendedPseudoClasses: Set<string> | undefined;
 
   constructor({
     mask,
@@ -447,6 +449,7 @@ export default class CosmeticFilter implements IFilter {
     this.id = undefined;
     this.rawLine = rawLine;
     this.scriptletDetails = undefined;
+    this.extendedPseudoClasses = undefined;
   }
 
   public isCosmeticFilter(): this is CosmeticFilter {
@@ -866,6 +869,20 @@ export default class CosmeticFilter implements IFilter {
 
   public isExtended(): boolean {
     return getBit(this.mask, COSMETICS_MASK.extended);
+  }
+
+  public hasUnsupportedExtendedPseudoClass(withPseudoClasses: string[]): boolean {
+    if (this.extendedPseudoClasses === undefined) {
+      this.extendedPseudoClasses = getExtendedPseudoClasses(this.getSelector());
+    }
+
+    for (const pseudoClass of withPseudoClasses) {
+      if (!this.extendedPseudoClasses.has(pseudoClass)) {
+        return true;
+      }
+    }
+
+    return false;
   }
 
   public isRemove(): boolean {


### PR DESCRIPTION
We want to support `:has` as a native CSS pseudo class. This PR allows users to produce a stylesheet with cosmetic filters which only includes supported pseudo classes regarded as extended. However, we have multiple aspects to determine if this approach really the most effective way to support `:has`.

1. Is generalization really required?
In this PR, I aim to generalize and extend the problem to all possible CSS pseudo classes. However, we may not need to target other pseudo classes rather than `:has`. `:has` solves a lot of problems in CSS selector by allowing users to select parent element. Also, I don't expect new pseudo class will be released in short. Therefore, we may not generalise the whole logic just to support `:has`.

2. Do we want to determine if a full selector is supported or not in runtime?
I think it depends on the cost of tokenization. We can still cache the results in the filter or cosmetic budget, but it will result in pretty much of computation and memory pressure. Instead, we can do the determination in the parse time as we're already checking if a selector is extended or not. In this case with an assumption that we only want to take care about `:has`, one consideration is to add a new bit field in `COSMETICS_MASK`.

3. How much safety do we want to add?
When building a stylesheet, the safety is ensured at block level. If we want to be safe about specific selector, we need to put them in separate blocks. Depending on the degree, we need to decide how many blocks we want to add.

---

If I wrap up, there are three things to decide:

- Target only `:has` or not
- Decision in parse time or runtime (hotpath in matching)
- How to check if a selector is only consisted with specific pseudo classes
- How many blocks we want to add for the fail-safe