### PR TITLE
feat: Optional support for native :has pseudo classes

### DIFF
--- a/packages/adblocker-extended-selectors/src/index.ts
+++ b/packages/adblocker-extended-selectors/src/index.ts
@@ -34,7 +34,7 @@ export function isSafeHasSelector(selector: string) {
       }
     });
   } catch (e) {
-    // stop travesing the ast once pseudo class different from :has is detected
+    // stop traversing the AST once a pseudo-class different from :has is detected
     return false;
   }
 

--- a/packages/adblocker-extended-selectors/src/index.ts
+++ b/packages/adblocker-extended-selectors/src/index.ts
@@ -35,7 +35,7 @@ export function isPureHasSelector(selector: string) {
       }
     });
   } catch (e) {
-    // stop traversing the AST once a pseudo-class different from :has is detected
+    // stop traversing the AST once an extended pseudo-class different from :has is detected
     return false;
   }
 

--- a/packages/adblocker-extended-selectors/src/index.ts
+++ b/packages/adblocker-extended-selectors/src/index.ts
@@ -19,7 +19,8 @@ export {
 import { EXTENDED_PSEUDO_CLASSES } from './extended.js';
 import { parse, walk } from './parse.js';
 
-export function isSafeHasSelector(selector: string) {
+// check if extended selector consists of :has extended pseudo-classes only
+export function isPureHasSelector(selector: string) {
   const ast = parse(selector);
 
   try {
@@ -27,8 +28,8 @@ export function isSafeHasSelector(selector: string) {
       if (
         node.type === 'pseudo-class' &&
         node.name !== undefined &&
-        EXTENDED_PSEUDO_CLASSES.has(node.name) &&
-        node.name !== 'has'
+        node.name !== 'has' &&
+        EXTENDED_PSEUDO_CLASSES.has(node.name)
       ) {
         throw new Error('not a :has');
       }

--- a/packages/adblocker-extended-selectors/src/index.ts
+++ b/packages/adblocker-extended-selectors/src/index.ts
@@ -6,7 +6,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-export { parse, tokenize } from './parse.js';
+export { parse, tokenize, walk } from './parse.js';
 export { querySelectorAll, matches } from './eval.js';
 export * from './types.js';
 export {

--- a/packages/adblocker-extended-selectors/src/index.ts
+++ b/packages/adblocker-extended-selectors/src/index.ts
@@ -6,7 +6,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-export { parse, tokenize, walk } from './parse.js';
+export { parse, tokenize } from './parse.js';
 export { querySelectorAll, matches } from './eval.js';
 export * from './types.js';
 export {
@@ -16,3 +16,27 @@ export {
   SelectorType,
   classifySelector,
 } from './extended.js';
+import { EXTENDED_PSEUDO_CLASSES } from './extended.js';
+import { parse, walk } from './parse.js';
+
+export function isSafeHasSelector(selector: string) {
+  const ast = parse(selector);
+
+  try {
+    walk(ast, (node) => {
+      if (
+        node.type === 'pseudo-class' &&
+        node.name !== undefined &&
+        EXTENDED_PSEUDO_CLASSES.has(node.name) &&
+        node.name !== 'has'
+      ) {
+        throw new Error('not a :has');
+      }
+    });
+  } catch (e) {
+    // stop travesing the ast once pseudo class different from :has is detected
+    return false;
+  }
+
+  return true;
+}

--- a/packages/adblocker-extended-selectors/src/parse.ts
+++ b/packages/adblocker-extended-selectors/src/parse.ts
@@ -569,7 +569,7 @@ function nestTokens(
 }
 
 // Traverse an AST (or part thereof), in depth-first order
-function walk(
+export function walk(
   node: AST | undefined,
   callback: (node: AST, parentNode?: AST) => void,
   o?: AST,

--- a/packages/adblocker/src/engine/bucket/cosmetic.ts
+++ b/packages/adblocker/src/engine/bucket/cosmetic.ts
@@ -292,7 +292,11 @@ export default class CosmeticFilterBucket {
         } else {
           genericHideRules.push(rule);
         }
-      } else if (rule.isExtended() === false || config.loadExtendedSelectors === true) {
+      } else if (
+        rule.isExtended() === false ||
+        config.loadExtendedSelectors === true ||
+        rule.isHas()
+      ) {
         hostnameSpecificRules.push(rule);
       }
     }
@@ -510,7 +514,12 @@ export default class CosmeticFilterBucket {
       for (const filter of extendedFilters) {
         const ast = filter.getSelectorAST();
         if (ast !== undefined) {
-          const attribute = filter.isRemove() ? undefined : filter.getStyleAttributeHash();
+          let attribute = undefined;
+          if (filter.isRemove()) {
+            attribute = `[${filter.getStyleAttributeHash()}]`;
+          } else if (filter.isHas()) {
+            attribute = filter.getSelector();
+          }
 
           if (attribute !== undefined) {
             extendedStyles.set(filter.getStyle(hidingStyle), attribute);
@@ -530,7 +539,7 @@ export default class CosmeticFilterBucket {
         }
 
         stylesheet += [...extendedStyles.entries()]
-          .map(([style, attribute]) => `[${attribute}] { ${style} }`)
+          .map(([style, attribute]) => `${attribute} { ${style} }`)
           .join('\n\n');
       }
     }

--- a/packages/adblocker/src/engine/bucket/cosmetic.ts
+++ b/packages/adblocker/src/engine/bucket/cosmetic.ts
@@ -26,7 +26,7 @@ import FiltersContainer from './filters.js';
  * injected in the page. This also takes care to no create rules with too many
  * selectors for Chrome, see: https://crbug.com/804179
  */
-export function createStylesheet(rules: string[], style: string): string {
+export function createStylesheet(rules: string[], style: string = DEFAULT_HIDING_STYLE): string {
   if (rules.length === 0) {
     return '';
   }
@@ -514,12 +514,7 @@ export default class CosmeticFilterBucket {
       for (const filter of extendedFilters) {
         const ast = filter.getSelectorAST();
         if (ast !== undefined) {
-          let attribute = undefined;
-          if (filter.isRemove()) {
-            attribute = `[${filter.getStyleAttributeHash()}]`;
-          } else if (filter.isHas()) {
-            attribute = filter.getSelector();
-          }
+          const attribute = filter.isRemove() ? undefined : filter.getStyleAttributeHash();
 
           if (attribute !== undefined) {
             extendedStyles.set(filter.getStyle(hidingStyle), attribute);
@@ -539,7 +534,7 @@ export default class CosmeticFilterBucket {
         }
 
         stylesheet += [...extendedStyles.entries()]
-          .map(([style, attribute]) => `${attribute} { ${style} }`)
+          .map(([style, attribute]) => `[${attribute}] { ${style} }`)
           .join('\n\n');
       }
     }

--- a/packages/adblocker/src/engine/bucket/cosmetic.ts
+++ b/packages/adblocker/src/engine/bucket/cosmetic.ts
@@ -295,7 +295,7 @@ export default class CosmeticFilterBucket {
       } else if (
         rule.isExtended() === false ||
         config.loadExtendedSelectors === true ||
-        rule.isHas()
+        rule.isSafeHasSelector()
       ) {
         hostnameSpecificRules.push(rule);
       }

--- a/packages/adblocker/src/engine/bucket/cosmetic.ts
+++ b/packages/adblocker/src/engine/bucket/cosmetic.ts
@@ -295,7 +295,7 @@ export default class CosmeticFilterBucket {
       } else if (
         rule.isExtended() === false ||
         config.loadExtendedSelectors === true ||
-        rule.isSafeHasSelector()
+        rule.isPureHasSelector()
       ) {
         hostnameSpecificRules.push(rule);
       }

--- a/packages/adblocker/src/engine/engine.ts
+++ b/packages/adblocker/src/engine/engine.ts
@@ -990,7 +990,8 @@ export default class FilterEngine extends EventEmitter<EngineEventHandlers> {
     getRulesFromDOM = true,
     getRulesFromHostname = true,
 
-    enableSafeHas = false,
+    // inject extended selector filters
+    injectPureHasSafely = false,
 
     hidingStyle,
     callerContext,
@@ -1009,7 +1010,7 @@ export default class FilterEngine extends EventEmitter<EngineEventHandlers> {
     getRulesFromDOM?: boolean;
     getRulesFromHostname?: boolean;
 
-    enableSafeHas?: boolean;
+    injectPureHasSafely?: boolean;
 
     hidingStyle?: string | undefined;
     callerContext?: any | undefined;
@@ -1104,7 +1105,7 @@ export default class FilterEngine extends EventEmitter<EngineEventHandlers> {
     const injections: CosmeticFilter[] = [];
     const styleFilters: CosmeticFilter[] = [];
     const extendedFilters: CosmeticFilter[] = [];
-    const safeHasFilters: CosmeticFilter[] = [];
+    const pureHasFilters: CosmeticFilter[] = [];
 
     if (filters.length !== 0) {
       // Apply unhide rules + dispatch
@@ -1127,8 +1128,8 @@ export default class FilterEngine extends EventEmitter<EngineEventHandlers> {
             applied = true;
           }
         } else if (filter.isExtended()) {
-          if (enableSafeHas && filter.isSafeHasSelector()) {
-            safeHasFilters.push(filter);
+          if (injectPureHasSafely && filter.isPureHasSelector()) {
+            pureHasFilters.push(filter);
             applied = true;
           }
           if (this.config.loadExtendedSelectors && getExtendedRules === true) {
@@ -1174,10 +1175,10 @@ export default class FilterEngine extends EventEmitter<EngineEventHandlers> {
       },
       { getBaseRules, allowGenericHides, hidingStyle },
     );
-    let { stylesheet } = stylesheets;
     const { extended } = stylesheets;
+    let { stylesheet } = stylesheets;
 
-    for (const safeHasFilter of safeHasFilters) {
+    for (const safeHasFilter of pureHasFilters) {
       stylesheet += `\n\n${createStylesheet([safeHasFilter.getSelector()], hidingStyle)}`;
     }
 

--- a/packages/adblocker/src/engine/engine.ts
+++ b/packages/adblocker/src/engine/engine.ts
@@ -1174,22 +1174,23 @@ export default class FilterEngine extends EventEmitter<EngineEventHandlers> {
       },
       { getBaseRules, allowGenericHides, hidingStyle },
     );
-    let styles = stylesheets.stylesheet;
+    let { stylesheet } = stylesheets;
+    const { extended } = stylesheets;
 
     for (const safeHasFilter of safeHasFilters) {
-      styles += `\n\n${createStylesheet([safeHasFilter.getSelector()], hidingStyle)}`;
+      stylesheet += `\n\n${createStylesheet([safeHasFilter.getSelector()], hidingStyle)}`;
     }
 
     // Emit events
-    if (styles.length !== 0) {
-      this.emit('style-injected', styles, url);
+    if (stylesheet.length !== 0) {
+      this.emit('style-injected', stylesheet, url);
     }
 
     return {
       active: true,
-      extended: stylesheets.extended,
+      extended,
       scripts,
-      styles,
+      styles: stylesheet,
     };
   }
 

--- a/packages/adblocker/src/engine/engine.ts
+++ b/packages/adblocker/src/engine/engine.ts
@@ -37,7 +37,7 @@ import { ICategory } from './metadata/categories.js';
 import { IOrganization } from './metadata/organizations.js';
 import { IPattern } from './metadata/patterns.js';
 
-export const ENGINE_VERSION = 699;
+export const ENGINE_VERSION = 700;
 
 function shouldApplyHideException(filters: NetworkFilter[]): boolean {
   if (filters.length === 0) {

--- a/packages/adblocker/src/engine/engine.ts
+++ b/packages/adblocker/src/engine/engine.ts
@@ -1104,7 +1104,7 @@ export default class FilterEngine extends EventEmitter<EngineEventHandlers> {
     const injections: CosmeticFilter[] = [];
     const styleFilters: CosmeticFilter[] = [];
     const extendedFilters: CosmeticFilter[] = [];
-    const hasFilters: CosmeticFilter[] = [];
+    const safeHasFilters: CosmeticFilter[] = [];
 
     if (filters.length !== 0) {
       // Apply unhide rules + dispatch
@@ -1127,8 +1127,8 @@ export default class FilterEngine extends EventEmitter<EngineEventHandlers> {
             applied = true;
           }
         } else if (filter.isExtended()) {
-          if (enableSafeHas && filter.isHas()) {
-            hasFilters.push(filter);
+          if (enableSafeHas && filter.isSafeHasSelector()) {
+            safeHasFilters.push(filter);
             applied = true;
           }
           if (this.config.loadExtendedSelectors && getExtendedRules === true) {
@@ -1176,8 +1176,8 @@ export default class FilterEngine extends EventEmitter<EngineEventHandlers> {
     );
     let styles = stylesheets.stylesheet;
 
-    for (const hasFilter of hasFilters) {
-      styles += `\n\n${createStylesheet([hasFilter.getSelector()], hidingStyle)}`;
+    for (const safeHasFilter of safeHasFilters) {
+      styles += `\n\n${createStylesheet([safeHasFilter.getSelector()], hidingStyle)}`;
     }
 
     // Emit events

--- a/packages/adblocker/src/engine/engine.ts
+++ b/packages/adblocker/src/engine/engine.ts
@@ -990,6 +990,9 @@ export default class FilterEngine extends EventEmitter<EngineEventHandlers> {
     getRulesFromDOM = true,
     getRulesFromHostname = true,
 
+    // try to load :has selectors without extended selectors support
+    getHasRulesSafely = false,
+
     hidingStyle,
     callerContext,
   }: {
@@ -1006,6 +1009,8 @@ export default class FilterEngine extends EventEmitter<EngineEventHandlers> {
     getExtendedRules?: boolean;
     getRulesFromDOM?: boolean;
     getRulesFromHostname?: boolean;
+
+    getHasRulesSafely?: boolean;
 
     hidingStyle?: string | undefined;
     callerContext?: any | undefined;
@@ -1122,7 +1127,7 @@ export default class FilterEngine extends EventEmitter<EngineEventHandlers> {
             applied = true;
           }
         } else if (filter.isExtended()) {
-          if (getExtendedRules === true) {
+          if (getExtendedRules === true || (getHasRulesSafely && filter.isHas())) {
             extendedFilters.push(filter);
             applied = true;
           }

--- a/packages/adblocker/src/filters/cosmetic.ts
+++ b/packages/adblocker/src/filters/cosmetic.ts
@@ -10,8 +10,7 @@ import {
   AST,
   classifySelector,
   SelectorType,
-  walk,
-  EXTENDED_PSEUDO_CLASSES,
+  isSafeHasSelector,
   parse as parseCssSelector,
 } from '@ghostery/adblocker-extended-selectors';
 
@@ -102,28 +101,6 @@ function isSimpleHrefSelector(selector: string, start: number): boolean {
     selector.startsWith('href*="', start) ||
     selector.startsWith('href="', start)
   );
-}
-
-function isSafeHasSelector(selector: string) {
-  const ast = parseCssSelector(selector);
-
-  try {
-    walk(ast, (node) => {
-      if (
-        node.type === 'pseudo-class' &&
-        node.name !== undefined &&
-        EXTENDED_PSEUDO_CLASSES.has(node.name) &&
-        node.name !== 'has'
-      ) {
-        throw new Error('not a :has');
-      }
-    });
-  } catch (e) {
-    // stop travesing the ast once pseudo class different from :has is detected
-    return false;
-  }
-
-  return true;
 }
 
 /**

--- a/packages/adblocker/src/filters/cosmetic.ts
+++ b/packages/adblocker/src/filters/cosmetic.ts
@@ -10,7 +10,7 @@ import {
   AST,
   classifySelector,
   SelectorType,
-  isSafeHasSelector,
+  isPureHasSelector,
   parse as parseCssSelector,
 } from '@ghostery/adblocker-extended-selectors';
 
@@ -147,7 +147,7 @@ const enum COSMETICS_MASK {
   isHrefSelector = 1 << 5,
   remove = 1 << 6,
   extended = 1 << 7,
-  isSafeHasSelector = 1 << 8,
+  isPureHasSelector = 1 << 8,
 }
 
 function computeFilterId(
@@ -330,8 +330,8 @@ export default class CosmeticFilter implements IFilter {
       if (selectorType === SelectorType.Extended) {
         mask = setBit(mask, COSMETICS_MASK.extended);
 
-        if (isSafeHasSelector(selector)) {
-          mask = setBit(mask, COSMETICS_MASK.isSafeHasSelector);
+        if (isPureHasSelector(selector)) {
+          mask = setBit(mask, COSMETICS_MASK.isPureHasSelector);
         }
       } else if (selectorType === SelectorType.Invalid || !isValidCss(selector)) {
         // console.error('Invalid', line);
@@ -878,8 +878,8 @@ export default class CosmeticFilter implements IFilter {
     return getBit(this.mask, COSMETICS_MASK.remove);
   }
 
-  public isSafeHasSelector(): boolean {
-    return getBit(this.mask, COSMETICS_MASK.isSafeHasSelector);
+  public isPureHasSelector(): boolean {
+    return getBit(this.mask, COSMETICS_MASK.isPureHasSelector);
   }
 
   public isUnhide(): boolean {

--- a/packages/adblocker/test/engine/engine.test.ts
+++ b/packages/adblocker/test/engine/engine.test.ts
@@ -942,6 +942,38 @@ foo.com###selector
       ).to.be.eql(`#id { visibility: none; }`);
     });
 
+    context.only('with has selectors', function () {
+      it('ignores if not allowed', function () {
+        expect(
+          Engine.parse('foo.com##aside:has(a.ad-remove)').getCosmeticsFilters({
+            domain: 'foo.com',
+            hostname: 'foo.com',
+            url: 'https://foo.com',
+            getExtendedRules: false,
+          }).styles,
+        ).to.be.eql('');
+      });
+
+      it('adds separate blocks if allowed', function () {
+        expect(
+          Engine.parse(
+            `
+            foo.com###test
+            foo.com##aside:has(a.ad-remove)
+          `,
+          ).getCosmeticsFilters({
+            domain: 'foo.com',
+            hostname: 'foo.com',
+            url: 'https://foo.com',
+            getExtendedRules: false,
+            getHasRulesSafely: true,
+          }).styles,
+        ).to.be.eql(
+          `#test { display: none !important; }\n\naside:has(a.ad-remove) { display: none !important; }`,
+        );
+      });
+    });
+
     it('handles custom :styles', () => {
       expect(
         Engine.parse(

--- a/packages/adblocker/test/engine/engine.test.ts
+++ b/packages/adblocker/test/engine/engine.test.ts
@@ -952,6 +952,16 @@ foo.com###selector
             getExtendedRules: false,
           }).styles,
         ).to.be.eql('');
+
+        expect(
+          Engine.parse('foo.com##aside:has(a.ad-remove)').getCosmeticsFilters({
+            domain: 'foo.com',
+            hostname: 'foo.com',
+            url: 'https://foo.com',
+            getExtendedRules: true,
+            enableSafeHas: false,
+          }).styles,
+        ).to.be.eql('');
       });
 
       it('adds separate blocks if allowed', function () {
@@ -966,7 +976,7 @@ foo.com###selector
             hostname: 'foo.com',
             url: 'https://foo.com',
             getExtendedRules: false,
-            getHasRulesSafely: true,
+            enableSafeHas: true,
           }).styles,
         ).to.be.eql(
           `#test { display: none !important; }\n\naside:has(a.ad-remove) { display: none !important; }`,

--- a/packages/adblocker/test/engine/engine.test.ts
+++ b/packages/adblocker/test/engine/engine.test.ts
@@ -959,7 +959,7 @@ foo.com###selector
             hostname: 'foo.com',
             url: 'https://foo.com',
             getExtendedRules: true,
-            enableSafeHas: false,
+            injectPureHasSafely: false,
           }).styles,
         ).to.be.eql('');
       });
@@ -973,7 +973,7 @@ foo.com###selector
             hostname: 'foo.com',
             url: 'https://foo.com',
             getExtendedRules: true,
-            enableSafeHas: true,
+            injectPureHasSafely: true,
           }).extended,
         ).to.be.empty;
 
@@ -985,7 +985,7 @@ foo.com###selector
             hostname: 'foo.com',
             url: 'https://foo.com',
             getExtendedRules: false,
-            enableSafeHas: true,
+            injectPureHasSafely: true,
           }).extended,
         ).to.be.empty;
       });
@@ -1002,7 +1002,7 @@ foo.com###selector
             hostname: 'foo.com',
             url: 'https://foo.com',
             getExtendedRules: false,
-            enableSafeHas: true,
+            injectPureHasSafely: true,
           }).styles,
         ).to.be.eql(
           `#test { display: none !important; }\n\naside:has(a.ad-remove) { display: none !important; }`,
@@ -1020,7 +1020,7 @@ foo.com###selector
             hostname: 'foo.com',
             url: 'https://foo.com',
             getExtendedRules: false,
-            enableSafeHas: true,
+            injectPureHasSafely: true,
           }).styles,
         ).to.be.eql(
           `#test { display: none !important; }\n\naside:has(a.ad-remove) { display: none !important; }`,

--- a/packages/adblocker/test/engine/engine.test.ts
+++ b/packages/adblocker/test/engine/engine.test.ts
@@ -942,7 +942,7 @@ foo.com###selector
       ).to.be.eql(`#id { visibility: none; }`);
     });
 
-    context.only('with has selectors', function () {
+    context('with has selectors', function () {
       it('ignores if not allowed', function () {
         expect(
           Engine.parse('foo.com##aside:has(a.ad-remove)').getCosmeticsFilters({

--- a/packages/adblocker/test/engine/engine.test.ts
+++ b/packages/adblocker/test/engine/engine.test.ts
@@ -964,6 +964,32 @@ foo.com###selector
         ).to.be.eql('');
       });
 
+      it('does not emit extended', function () {
+        expect(
+          Engine.parse('foo.com##aside:has(a.ad-remove)', {
+            loadExtendedSelectors: false,
+          }).getCosmeticsFilters({
+            domain: 'foo.com',
+            hostname: 'foo.com',
+            url: 'https://foo.com',
+            getExtendedRules: true,
+            enableSafeHas: true,
+          }).extended,
+        ).to.be.empty;
+
+        expect(
+          Engine.parse('foo.com##aside:has(a.ad-remove)', {
+            loadExtendedSelectors: false,
+          }).getCosmeticsFilters({
+            domain: 'foo.com',
+            hostname: 'foo.com',
+            url: 'https://foo.com',
+            getExtendedRules: false,
+            enableSafeHas: true,
+          }).extended,
+        ).to.be.empty;
+      });
+
       it('adds separate blocks if allowed', function () {
         expect(
           Engine.parse(
@@ -971,6 +997,24 @@ foo.com###selector
             foo.com###test
             foo.com##aside:has(a.ad-remove)
           `,
+          ).getCosmeticsFilters({
+            domain: 'foo.com',
+            hostname: 'foo.com',
+            url: 'https://foo.com',
+            getExtendedRules: false,
+            enableSafeHas: true,
+          }).styles,
+        ).to.be.eql(
+          `#test { display: none !important; }\n\naside:has(a.ad-remove) { display: none !important; }`,
+        );
+
+        expect(
+          Engine.parse(
+            `
+            foo.com###test
+            foo.com##aside:has(a.ad-remove)
+          `,
+            { loadExtendedSelectors: false },
           ).getCosmeticsFilters({
             domain: 'foo.com',
             hostname: 'foo.com',


### PR DESCRIPTION
Alternative for https://github.com/ghostery/adblocker/pull/4442

As :has pseudo classes are now supported by the majority of modern browsers it is fine to run filters with :has selectors as regular CSS selectors. But to be on the safe side, we do inject them in separate CSS blocks.

It is important to keep in mind, by default and in Ghostery extension extended selectors are not enabled. This change, loads extended filters which are `:has` only, but does not inject them as extended selector but rather like regular css selectors.

