### PR TITLE
chore: export referenceable components

### DIFF
--- a/packages/adblocker/src/index.ts
+++ b/packages/adblocker/src/index.ts
@@ -23,6 +23,7 @@ export type {
 } from './request.js';
 export { default as CosmeticFilter } from './filters/cosmetic.js';
 export { default as NetworkFilter } from './filters/network.js';
+export { default as Preprocessor } from './preprocessor.js';
 export {
   FilterType,
   detectFilterType,
@@ -33,7 +34,7 @@ export {
   parseFilter,
   parseFilters,
 } from './lists.js';
-export type { IListDiff, IRawDiff } from './lists.js';
+export type { IListDiff, IRawDiff, NonSupportedFilter } from './lists.js';
 export * from './fetch.js';
 export { hasUnicode, tokenizeNoSkip as tokenize } from './utils.js';
 export { isUTF8 } from './encoding.js';

--- a/packages/adblocker/src/lists.ts
+++ b/packages/adblocker/src/lists.ts
@@ -153,7 +153,7 @@ export function f(strings: TemplateStringsArray): NetworkFilter | CosmeticFilter
   return parseFilter(strings[0]);
 }
 
-interface NonSupportedFilter {
+export interface NonSupportedFilter {
   lineNumber: number;
   filter: string;
   filterType: FilterType;


### PR DESCRIPTION
We have some components exported indirectly via exported functions. This prevents possible type inferencing errors.

refs #4465