### PR TITLE
chore: use `Frame.detached` for puppeteer

### DIFF
--- a/packages/adblocker-puppeteer/src/index.ts
+++ b/packages/adblocker-puppeteer/src/index.ts
@@ -253,7 +253,7 @@ export class PuppeteerBlocker extends FiltersEngine {
     // should not actively monitor the DOM for changes.
     let numberOfIterations = 0;
     do {
-      if (frame.isDetached()) {
+      if (frame.detached) {
         break;
       }
 


### PR DESCRIPTION
`Frame.isDetached()` is now deprecated and replaced to `Frame.detached` getter.

refs https://pptr.dev/api/puppeteer.frame.isdetached