### PR TITLE
Fix: hidingStyles should not be cached

### DIFF
--- a/packages/adblocker/src/engine/bucket/cosmetic.ts
+++ b/packages/adblocker/src/engine/bucket/cosmetic.ts
@@ -362,7 +362,6 @@ export default class CosmeticFilterBucket {
     getRulesFromDOM?: boolean;
     getRulesFromHostname?: boolean;
 
-    hidingStyle?: string | undefined;
     isFilterExcluded?: (filter: CosmeticFilter) => boolean;
   }): {
     filters: CosmeticFilter[];

--- a/packages/adblocker/src/engine/bucket/cosmetic.ts
+++ b/packages/adblocker/src/engine/bucket/cosmetic.ts
@@ -347,7 +347,6 @@ export default class CosmeticFilterBucket {
     getRulesFromDOM = true,
     getRulesFromHostname = true,
 
-    hidingStyle = DEFAULT_HIDING_STYLE,
     isFilterExcluded,
   }: {
     domain: string;
@@ -401,7 +400,7 @@ export default class CosmeticFilterBucket {
     // matches the hostname and domain since some generic rules can specify
     // negated hostnames and entities (e.g.: ~foo.*##generic).
     if (allowGenericHides === true && getRulesFromHostname === true) {
-      const genericRules = this.getGenericRules(hidingStyle);
+      const genericRules = this.getGenericRules();
       for (const filter of genericRules) {
         if (filter.match(hostname, domain) === true && !isFilterExcluded?.(filter)) {
           filters.push(filter);
@@ -496,9 +495,11 @@ export default class CosmeticFilterBucket {
     extended: IMessageFromBackground['extended'];
   } {
     let stylesheet: string =
-      getBaseRules === false || allowGenericHides === false
-        ? ''
-        : this.getBaseStylesheet(hidingStyle);
+      getBaseRules === false || allowGenericHides === false ? '' : this.getBaseStylesheet();
+
+    if (hidingStyle !== DEFAULT_HIDING_STYLE) {
+      stylesheet = stylesheet.replace(DEFAULT_HIDING_STYLE, hidingStyle);
+    }
 
     if (filters.length !== 0) {
       if (stylesheet.length !== 0) {
@@ -545,9 +546,9 @@ export default class CosmeticFilterBucket {
    * Return the list of filters which can potentially be un-hidden by another
    * rule currently contained in the cosmetic bucket.
    */
-  private getGenericRules(hidingStyle: string): CosmeticFilter[] {
+  private getGenericRules(): CosmeticFilter[] {
     if (this.extraGenericRules === null) {
-      return this.lazyPopulateGenericRulesCache(hidingStyle).genericRules;
+      return this.lazyPopulateGenericRulesCache().genericRules;
     }
     return this.extraGenericRules;
   }
@@ -559,9 +560,9 @@ export default class CosmeticFilterBucket {
    * the same for all sites. We generate it once and re-use it any-time we want
    * to inject it.
    */
-  private getBaseStylesheet(hidingStyle: string): string {
+  private getBaseStylesheet(): string {
     if (this.baseStylesheet === null) {
-      return this.lazyPopulateGenericRulesCache(hidingStyle).baseStylesheet;
+      return this.lazyPopulateGenericRulesCache().baseStylesheet;
     }
     return this.baseStylesheet;
   }
@@ -573,7 +574,7 @@ export default class CosmeticFilterBucket {
    * be un-hidden. Since this list will not change between updates we can
    * generate once and use many times.
    */
-  private lazyPopulateGenericRulesCache(hidingStyle: string): {
+  private lazyPopulateGenericRulesCache(): {
     baseStylesheet: string;
     genericRules: CosmeticFilter[];
   } {
@@ -608,7 +609,7 @@ export default class CosmeticFilterBucket {
         }
       }
 
-      this.baseStylesheet = createStylesheetFromRules(cannotBeHiddenRules, hidingStyle);
+      this.baseStylesheet = createStylesheetFromRules(cannotBeHiddenRules);
       this.extraGenericRules = canBeHiddenRules;
     }
 

--- a/packages/adblocker/src/engine/engine.ts
+++ b/packages/adblocker/src/engine/engine.ts
@@ -1081,7 +1081,6 @@ export default class FilterEngine extends EventEmitter<EngineEventHandlers> {
       getRulesFromDOM,
       getRulesFromHostname,
 
-      hidingStyle,
       isFilterExcluded: this.isFilterExcluded.bind(this),
     });
 

--- a/packages/adblocker/test/engine/engine.test.ts
+++ b/packages/adblocker/test/engine/engine.test.ts
@@ -931,15 +931,40 @@ foo.com###selector
       });
     });
 
-    it('handles custom default hiding styles', () => {
-      expect(
-        Engine.parse('foo.com###id').getCosmeticsFilters({
-          domain: 'foo.com',
-          hostname: 'foo.com',
-          url: 'https://foo.com',
-          hidingStyle: 'visibility: none;',
-        }).styles,
-      ).to.be.eql(`#id { visibility: none; }`);
+    context('with hidingStyle', () => {
+      it('handles custom default hiding styles', () => {
+        expect(
+          Engine.parse('foo.com###id').getCosmeticsFilters({
+            domain: 'foo.com',
+            hostname: 'foo.com',
+            url: 'https://foo.com',
+            hidingStyle: 'visibility: none;',
+          }).styles,
+        ).to.be.eql(`#id { visibility: none; }`);
+      });
+
+      it('affects generic filters', () => {
+        const engine = Engine.parse('##test');
+        expect(
+          engine.getCosmeticsFilters({
+            domain: 'foo.com',
+            hostname: 'foo.com',
+            url: 'https://foo.com',
+            getBaseRules: true,
+            hidingStyle: 'visibility: none;',
+          }).styles,
+        ).to.be.eql(`test { visibility: none; }`);
+        // generic filters are cached but should still respect hidingStyle
+        expect(
+          engine.getCosmeticsFilters({
+            domain: 'foo.com',
+            hostname: 'foo.com',
+            url: 'https://foo.com',
+            getBaseRules: true,
+            hidingStyle: 'visibility: collapse;',
+          }).styles,
+        ).to.be.eql(`test { visibility: collapse; }`);
+      });
     });
 
     context('with has selectors', function () {


### PR DESCRIPTION
Generic filters like `##test` or `~foo.com##[data-test]` should be injected to all pages so we cache in the `baseStylesheet`. `hidingStyle` is meant to affect those base stylesheets but the implementation from https://github.com/ghostery/adblocker/pull/4238 did not take the caching into consideration. In result `hidingStyle` was affecting base stylesheet only if provided on first call to `getCosmeticsFilters` and otherwise it was not applied to base stylesheets at all.