### PR TITLE
refactor: optimize wireformat size

### DIFF
--- a/packages/adblocker/src/preprocessor.ts
+++ b/packages/adblocker/src/preprocessor.ts
@@ -1,4 +1,4 @@
-import { StaticDataView, sizeOfUTF8 } from './data-view.js';
+import { StaticDataView, sizeOfASCII } from './data-view.js';
 
 export type EnvKeys =
   | 'ext_ghostery'
@@ -202,7 +202,7 @@ export default class Preprocessor {
   }
 
   public static deserialize(view: StaticDataView): Preprocessor {
-    const condition = view.getUTF8();
+    const condition = view.getASCII();
 
     const filterIDs = new Set<FilterId>();
     for (let i = 0, l = view.getUint32(); i < l; i++) {
@@ -234,7 +234,7 @@ export default class Preprocessor {
   }
 
   public serialize(view: StaticDataView): void {
-    view.pushUTF8(this.condition);
+    view.pushASCII(this.condition);
 
     view.pushUint32(this.filterIDs.size);
     for (const filterID of this.filterIDs) {
@@ -243,7 +243,7 @@ export default class Preprocessor {
   }
 
   public getSerializedSize(): number {
-    let estimatedSize = sizeOfUTF8(this.condition);
+    let estimatedSize = sizeOfASCII(this.condition);
 
     estimatedSize += (1 + this.filterIDs.size) * 4;
 

--- a/packages/adblocker/src/resources.ts
+++ b/packages/adblocker/src/resources.ts
@@ -424,9 +424,7 @@ export default class Resources {
     for (const { name, aliases, body: content, contentType } of this.resources) {
       buffer.pushASCII(name);
       buffer.pushUint16(aliases.length);
-      for (const alias of aliases) {
-        buffer.pushASCII(alias);
-      }
+      aliases.forEach((alias) => buffer.pushASCII(alias));
       buffer.pushUTF8(content);
       buffer.pushASCII(contentType);
     }
@@ -455,9 +453,7 @@ export default class Resources {
       buffer.pushUint8(mask);
       buffer.pushASCII(name);
       buffer.pushUint16(aliases.length);
-      for (const alias of aliases) {
-        buffer.pushASCII(alias);
-      }
+      aliases.forEach((alias) => buffer.pushASCII(alias));
       buffer.pushUTF8(content);
       buffer.pushUint16(dependencies.length);
       dependencies.forEach((dependency) => buffer.pushASCII(dependency));

--- a/packages/adblocker/src/resources.ts
+++ b/packages/adblocker/src/resources.ts
@@ -125,9 +125,9 @@ const assembleScript = (script: string, dependencies: string[] = []): string =>
 
 const enum RESOURCES_MASK {
   executionWorldOfMain = 1 << 0,
-  executionWorldOfIsolated = 2 << 0,
-  scriptletElevationRequired = 3 << 0,
-  scriptletElevationNotRequired = 4 << 0,
+  executionWorldOfIsolated = 1 << 1,
+  scriptletElevationRequired = 1 << 2,
+  scriptletElevationNotRequired = 1 << 3,
 }
 
 /**

--- a/packages/adblocker/src/resources.ts
+++ b/packages/adblocker/src/resources.ts
@@ -398,7 +398,7 @@ export default class Resources {
     }
 
     estimatedSize += 2 * sizeOfByte();
-    estimatedSize += this.scriptlets.length; // mask
+    estimatedSize += this.scriptlets.length * sizeOfByte(); // mask
     for (const { name, aliases, body: content, dependencies } of this.scriptlets) {
       estimatedSize += sizeOfASCII(name);
       estimatedSize += aliases.reduce(
@@ -424,7 +424,9 @@ export default class Resources {
     for (const { name, aliases, body: content, contentType } of this.resources) {
       buffer.pushASCII(name);
       buffer.pushUint16(aliases.length);
-      aliases.forEach((alias) => buffer.pushASCII(alias));
+      for (const alias of aliases) {
+        buffer.pushASCII(alias);
+      }
       buffer.pushUTF8(content);
       buffer.pushASCII(contentType);
     }
@@ -453,10 +455,14 @@ export default class Resources {
       buffer.pushUint8(mask);
       buffer.pushASCII(name);
       buffer.pushUint16(aliases.length);
-      aliases.forEach((alias) => buffer.pushASCII(alias));
+      for (const alias of aliases) {
+        buffer.pushASCII(alias);
+      }
       buffer.pushUTF8(content);
       buffer.pushUint16(dependencies.length);
-      dependencies.forEach((dependency) => buffer.pushASCII(dependency));
+      for (const dependency of dependencies) {
+        buffer.pushASCII(dependency);
+      }
     }
   }
 }

--- a/packages/adblocker/src/resources.ts
+++ b/packages/adblocker/src/resources.ts
@@ -444,7 +444,7 @@ export default class Resources {
       let mask = 0;
       if (executionWorld === 'MAIN') {
         mask = setBit(mask, RESOURCES_MASK.executionWorldOfMain);
-      } else {
+      } else if (executionWorld === 'ISOLATED') {
         mask = setBit(mask, RESOURCES_MASK.executionWorldOfIsolated);
       }
       if (requiresTrust === true) {

--- a/packages/adblocker/src/resources.ts
+++ b/packages/adblocker/src/resources.ts
@@ -8,7 +8,7 @@
 
 import { getResourceForMime } from '@remusao/small';
 
-import { StaticDataView, sizeOfUTF8, sizeOfASCII, sizeOfBool, sizeOfByte } from './data-view.js';
+import { StaticDataView, sizeOfUTF8, sizeOfASCII, sizeOfByte } from './data-view.js';
 import { getBit, setBit } from './utils.js';
 
 // Polyfill for `btoa`


### PR DESCRIPTION
This improves binary size by
- Replacing 4 boolean values in resources into single byte unsigned integer
- Limiting a space for encoded preprocessor condition to ascii