### PR TITLE
fix: custom styles being ignored for pure has filters

### DIFF
--- a/packages/adblocker/src/engine/engine.ts
+++ b/packages/adblocker/src/engine/engine.ts
@@ -1178,7 +1178,11 @@ export default class FilterEngine extends EventEmitter<EngineEventHandlers> {
     let { stylesheet } = stylesheets;
 
     for (const safeHasFilter of pureHasFilters) {
-      stylesheet += `\n\n${createStylesheet([safeHasFilter.getSelector()], hidingStyle)}`;
+      if (safeHasFilter.hasCustomStyle()) {
+        stylesheet += `\n\n${createStylesheet([safeHasFilter.getSelector()], safeHasFilter.getStyle())}`;
+      } else {
+        stylesheet += `\n\n${createStylesheet([safeHasFilter.getSelector()], hidingStyle)}`;
+      }
     }
 
     // Emit events

--- a/packages/adblocker/src/engine/engine.ts
+++ b/packages/adblocker/src/engine/engine.ts
@@ -1178,11 +1178,7 @@ export default class FilterEngine extends EventEmitter<EngineEventHandlers> {
     let { stylesheet } = stylesheets;
 
     for (const safeHasFilter of pureHasFilters) {
-      if (safeHasFilter.hasCustomStyle()) {
-        stylesheet += `\n\n${createStylesheet([safeHasFilter.getSelector()], safeHasFilter.getStyle())}`;
-      } else {
-        stylesheet += `\n\n${createStylesheet([safeHasFilter.getSelector()], hidingStyle)}`;
-      }
+      stylesheet += `\n\n${createStylesheet([safeHasFilter.getSelector()], safeHasFilter.hasCustomStyle() ? safeHasFilter.getStyle() : hidingStyle)}`;
     }
 
     // Emit events

--- a/packages/adblocker/test/engine/engine.test.ts
+++ b/packages/adblocker/test/engine/engine.test.ts
@@ -1051,6 +1051,35 @@ foo.com###selector
           `#test { display: none !important; }\n\naside:has(a.ad-remove) { display: none !important; }`,
         );
       });
+
+      it('respects custom styles', function () {
+        expect(
+          Engine.parse(`foo.com##body:has(a):style(visibility: hidden !important;)`, {
+            loadExtendedSelectors: false,
+          }).getCosmeticsFilters({
+            domain: 'foo.com',
+            hostname: 'foo.com',
+            url: 'https://foo.com',
+            getExtendedRules: false,
+            injectPureHasSafely: true,
+          }).styles,
+        ).to.be.eql(`\n\nbody:has(a) { visibility: hidden !important; }`);
+
+        expect(
+          Engine.parse(
+            `
+            foo.com##body:has(a):style(visibility: hidden !important;)
+            foo.com#@#body:has(a):style(visibility: hidden !important;)
+          `,
+          ).getCosmeticsFilters({
+            domain: 'foo.com',
+            hostname: 'foo.com',
+            url: 'https://foo.com',
+            getExtendedRules: false,
+            injectPureHasSafely: true,
+          }).styles,
+        ).to.be.eql('');
+      });
     });
 
     context('with :styles psuedo-class', function () {


### PR DESCRIPTION
fixes https://github.com/ghostery/broken-page-reports/issues/1009

This PR addresses custom styles being ignored when pure has filters matched.

For example, a filter (`domain.tld##body:has(something):style(overflow: auto !important)`) will be `body:has(something) { display: none !important; }`.