### PR TITLE
feat(internal): allow priorities script to load filters from remote

### DIFF
--- a/packages/adblocker/.gitignore
+++ b/packages/adblocker/.gitignore
@@ -1,0 +1,1 @@
+.list-cache/

--- a/packages/adblocker/src/filters/network.ts
+++ b/packages/adblocker/src/filters/network.ts
@@ -623,7 +623,7 @@ function getFilterReplaceOptionValue(
  * Depending on the filter option key, the function to collect filter option value can vary.
  * For the generic filter option value, it'll use `getFilterOptionValue` function to get the value.
  */
-function getFilterOptions(line: string, pos: number, end: number): Array<[string, string]> {
+export function getFilterOptions(line: string, pos: number, end: number): Array<[string, string]> {
   const options: Array<[string, string]> = [];
 
   let name: string | undefined;

--- a/packages/adblocker/tools/priorities.ts
+++ b/packages/adblocker/tools/priorities.ts
@@ -224,7 +224,7 @@ async function loadAllLists(): Promise<string> {
           for (const [key, value] of options) {
             if (NetworkFilter.parse(`${line.slice(0, optionStart)}$${key}=${value}`) === null) {
               found = true;
-              unsupported.incr(key);
+              unsupported.incr('$' + key);
             }
           }
 

--- a/packages/adblocker/tools/priorities.ts
+++ b/packages/adblocker/tools/priorities.ts
@@ -167,7 +167,7 @@ async function loadAllListsFromRemote(ignoreCache: boolean): Promise<string> {
     if (ignoreCache || body.length === 0) {
       body = await fetchList(remoteUrl);
     }
-    // Mark as an error when tried both cache and remote then all failed
+    // Mark as an error when both cache and remote failed
     if (body.length === 0) {
       errors.push(remoteUrl);
     } else {

--- a/packages/adblocker/tools/priorities.ts
+++ b/packages/adblocker/tools/priorities.ts
@@ -166,13 +166,15 @@ async function loadAllListsFromRemote(ignoreCache: boolean): Promise<string> {
       errors.push(remoteUrl);
     } else {
       // Update cache
-      writeFileSync(cacheUrl, body, 'utf8');
+      writeFileSync(cacheUrl, Date.now().toString() + '=' + body, 'utf8');
       contents.push(body);
     }
   }
 
-  console.warn(`[WARN] Possibly failed sources:
+  if (errors.length !== 0) {
+    console.warn(`[WARN] Possibly failed sources:
 ${errors.map((error) => `  - "${error}"`).join('\n')}`);
+  }
 
   return contents.join('\n');
 }

--- a/packages/adblocker/tools/priorities.ts
+++ b/packages/adblocker/tools/priorities.ts
@@ -97,7 +97,9 @@ function retrieveRemoteUrl(url: string): string {
       return 'https://easylist.to/easylist/' + variant;
     }
     case 'peter-lowe': {
-      return 'https://pgl.yoyo.org/as/serverlist.php?hostformat=adblockplus&mimetype=plaintext';
+      // We're skipping this since it doesn't include any complex filter syntax.
+      // return 'https://pgl.yoyo.org/as/serverlist.php?hostformat=adblockplus&mimetype=plaintext';
+      return '';
     }
     default: {
       throw new Error('Unknown filter list URL format: ' + path);
@@ -157,7 +159,9 @@ async function loadAllListsFromRemote(ignoreCache: boolean): Promise<string> {
     mkdirSync(CACHE_DIR, { recursive: true });
   }
 
-  for (const remoteUrl of fullLists.map(retrieveRemoteUrl)) {
+  for (const remoteUrl of fullLists
+    .map(retrieveRemoteUrl)
+    .filter((remoteUrl) => remoteUrl.length !== 0)) {
     const cacheUrl = retrieveCacheUrl(remoteUrl);
     let body = retrieveListCache(cacheUrl);
     if (ignoreCache || body.length === 0) {

--- a/packages/adblocker/tools/priorities.ts
+++ b/packages/adblocker/tools/priorities.ts
@@ -17,6 +17,8 @@ import {
   NetworkFilter,
   FilterType,
 } from '../src/index.js';
+import { findLastIndexOfUnescapedCharacter } from '../src/utils.js';
+import { getFilterOptions } from '../src/filters/network.js';
 
 class Counter<K> {
   private counter: Map<K, number>;
@@ -200,7 +202,7 @@ async function loadAllLists(): Promise<string> {
         // Filter is not supported as is, try to find out why.
         if (NetworkFilter.parse(line) === null) {
           numberOfFiltersUnsupported += 1;
-          const optionStart = line.lastIndexOf('$');
+          const optionStart = findLastIndexOfUnescapedCharacter(line, '$');
 
           // No option and not supported
           if (optionStart === -1) {
@@ -218,11 +220,11 @@ async function loadAllLists(): Promise<string> {
           // failure. If we can't find one such option, we just report the full line
           // as not being supported.
           let found = false;
-          const options = line.slice(optionStart + 1).split(',');
-          for (const option of options) {
-            if (NetworkFilter.parse(`${line.slice(0, optionStart)}$${option}`) === null) {
+          const options = getFilterOptions(line, optionStart + 1, line.length);
+          for (const [key, value] of options) {
+            if (NetworkFilter.parse(`${line.slice(0, optionStart)}$${key}=${value}`) === null) {
               found = true;
-              unsupported.incr(option);
+              unsupported.incr(key);
             }
           }
 


### PR DESCRIPTION
We're filtering invalid filters out from our backend and this is preventing us to acquire a proper sight.

```zsh
// bin/zsh
// Go to ./packages/adblocker from repository root
[[ "$(readlink -f)" != *"/packages/adblocker/"* ]] && cd packages/adblocker

// Use remote filter lists (not from our backend = local files)
// -o, --use-origin-filter
yarn tsx ./scripts/priorities.ts -o

// Use remote filter lists but always fetch
// -i, --ignore-cache
//   ... this option is only effective with -o
yarn tsx ./scripts/priorities.ts -o -i
```