### PR TITLE
refactor: replace `fastStartsWith` & `fastStartsWithFrom`

### DIFF
--- a/packages/adblocker/src/filters/cosmetic.ts
+++ b/packages/adblocker/src/filters/cosmetic.ts
@@ -30,7 +30,6 @@ import {
 import {
   fastHash,
   fastHashBetween,
-  fastStartsWithFrom,
   getBit,
   hasUnicode,
   setBit,
@@ -285,7 +284,7 @@ export default class CosmeticFilter implements IFilter {
     // Deal with HTML filters
     if (line.charCodeAt(suffixStartIndex) === 94 /* '^' */) {
       if (
-        fastStartsWithFrom(line, 'script:has-text(', suffixStartIndex + 1) === false ||
+        line.startsWith('script:has-text(', suffixStartIndex + 1) === false ||
         line.charCodeAt(line.length - 1) !== 41 /* ')' */
       ) {
         return null;
@@ -308,7 +307,7 @@ export default class CosmeticFilter implements IFilter {
     } else if (
       line.length - suffixStartIndex > 4 &&
       line.charCodeAt(suffixStartIndex) === 43 /* '+' */ &&
-      fastStartsWithFrom(line, '+js(', suffixStartIndex)
+      line.startsWith('+js(', suffixStartIndex)
     ) {
       // Generic scriptlets are invalid, unless they are un-hide
       if (

--- a/packages/adblocker/src/filters/network.ts
+++ b/packages/adblocker/src/filters/network.ts
@@ -23,8 +23,6 @@ import {
   bitCount,
   clearBit,
   fastHash,
-  fastStartsWith,
-  fastStartsWithFrom,
   getBit,
   hasUnicode,
   isAlpha,
@@ -1092,7 +1090,7 @@ export default class NetworkFilter implements IFilter {
       if (getBit(mask, NETWORK_FILTER_MASK.isLeftAnchor)) {
         if (
           filterIndexEnd - filterIndexStart === 5 &&
-          fastStartsWithFrom(line, 'ws://', filterIndexStart)
+          line.startsWith('ws://', filterIndexStart)
         ) {
           mask = setBit(mask, NETWORK_FILTER_MASK.fromWebsocket);
           mask = clearBit(mask, NETWORK_FILTER_MASK.isLeftAnchor);
@@ -1101,7 +1099,7 @@ export default class NetworkFilter implements IFilter {
           filterIndexStart = filterIndexEnd;
         } else if (
           filterIndexEnd - filterIndexStart === 7 &&
-          fastStartsWithFrom(line, 'http://', filterIndexStart)
+          line.startsWith('http://', filterIndexStart)
         ) {
           mask = setBit(mask, NETWORK_FILTER_MASK.fromHttp);
           mask = clearBit(mask, NETWORK_FILTER_MASK.fromHttps);
@@ -1109,7 +1107,7 @@ export default class NetworkFilter implements IFilter {
           filterIndexStart = filterIndexEnd;
         } else if (
           filterIndexEnd - filterIndexStart === 8 &&
-          fastStartsWithFrom(line, 'https://', filterIndexStart)
+          line.startsWith('https://', filterIndexStart)
         ) {
           mask = setBit(mask, NETWORK_FILTER_MASK.fromHttps);
           mask = clearBit(mask, NETWORK_FILTER_MASK.fromHttp);
@@ -1117,7 +1115,7 @@ export default class NetworkFilter implements IFilter {
           filterIndexStart = filterIndexEnd;
         } else if (
           filterIndexEnd - filterIndexStart === 8 &&
-          fastStartsWithFrom(line, 'http*://', filterIndexStart)
+          line.startsWith('http*://', filterIndexStart)
         ) {
           mask = setBit(mask, NETWORK_FILTER_MASK.fromHttps);
           mask = setBit(mask, NETWORK_FILTER_MASK.fromHttp);
@@ -2046,8 +2044,7 @@ function checkPattern(filter: NetworkFilter, request: Request): boolean {
       // Since this is not a regex, the filter pattern must follow the hostname
       // with nothing in between. So we extract the part of the URL following
       // after hostname and will perform the matching on it.
-      return fastStartsWithFrom(
-        request.url,
+      return request.url.startsWith(
         pattern,
         request.url.indexOf(filterHostname) + filterHostname.length,
       );
@@ -2070,7 +2067,7 @@ function checkPattern(filter: NetworkFilter, request: Request): boolean {
     return request.url === pattern;
   } else if (filter.isLeftAnchor()) {
     // |pattern
-    return fastStartsWith(request.url, pattern);
+    return request.url.startsWith(pattern);
   } else if (filter.isRightAnchor()) {
     // pattern|
     return request.url.endsWith(pattern);

--- a/packages/adblocker/src/lists.ts
+++ b/packages/adblocker/src/lists.ts
@@ -10,7 +10,6 @@ import Config from './config.js';
 import CosmeticFilter from './filters/cosmetic.js';
 import NetworkFilter from './filters/network.js';
 import Preprocessor, { PreprocessorTokens, detectPreprocessor } from './preprocessor.js';
-import { fastStartsWith, fastStartsWithFrom } from './utils.js';
 
 export const enum FilterType {
   NOT_SUPPORTED = 0,
@@ -46,7 +45,7 @@ export function detectFilterType(
   if (
     firstCharCode === 33 /* '!' */ ||
     (firstCharCode === 35 /* '#' */ && secondCharCode <= 32) ||
-    (firstCharCode === 91 /* '[' */ && fastStartsWith(line, '[Adblock'))
+    (firstCharCode === 91 /* '[' */ && line.startsWith('[Adblock'))
   ) {
     if (extendedNonSupportedTypes) {
       return FilterType.NOT_SUPPORTED_COMMENT;
@@ -86,8 +85,7 @@ export function detectFilterType(
     // Ignore Adguard HTML rewrite rules
     if (
       afterDollarCharCode === 36 /* '$' */ ||
-      (afterDollarCharCode === 64 /* '@' */ &&
-        fastStartsWithFrom(line, /* $@$ */ '@$', afterDollarIndex))
+      (afterDollarCharCode === 64 /* '@' */ && line.startsWith(/* $@$ */ '@$', afterDollarIndex))
     ) {
       if (extendedNonSupportedTypes) {
         return FilterType.NOT_SUPPORTED_ADGUARD;
@@ -104,27 +102,24 @@ export function detectFilterType(
 
     if (
       afterSharpCharCode === 35 /* '#'*/ ||
-      (afterSharpCharCode === 64 /* '@' */ &&
-        fastStartsWithFrom(line, /* #@# */ '@#', afterSharpIndex))
+      (afterSharpCharCode === 64 /* '@' */ && line.startsWith(/* #@# */ '@#', afterSharpIndex))
       // TODO - support ADB/AdGuard extended css selectors
       // || (afterSharpCharCode === 63 /* '?' */ &&
-      //   fastStartsWithFrom(line, /* #?# */ '?#', afterSharpIndex))
+      //   line.startsWith(/* #?# */ '?#', afterSharpIndex))
     ) {
       // Parse supported cosmetic filter
       // `##` `#@#`
       return FilterType.COSMETIC;
     } else if (
       (afterSharpCharCode === 64 /* '@'*/ &&
-        (fastStartsWithFrom(line, /* #@$# */ '@$#', afterSharpIndex) ||
-          fastStartsWithFrom(line, /* #@%# */ '@%#', afterSharpIndex) ||
-          fastStartsWithFrom(line, /* #@?# */ '@?#', afterSharpIndex))) ||
-      (afterSharpCharCode === 37 /* '%' */ &&
-        fastStartsWithFrom(line, /* #%# */ '%#', afterSharpIndex)) ||
+        (line.startsWith(/* #@$# */ '@$#', afterSharpIndex) ||
+          line.startsWith(/* #@%# */ '@%#', afterSharpIndex) ||
+          line.startsWith(/* #@?# */ '@?#', afterSharpIndex))) ||
+      (afterSharpCharCode === 37 /* '%' */ && line.startsWith(/* #%# */ '%#', afterSharpIndex)) ||
       (afterSharpCharCode === 36 /* '$' */ &&
-        (fastStartsWithFrom(line, /* #$# */ '$#', afterSharpIndex) ||
-          fastStartsWithFrom(line, /* #$?# */ '$?#', afterSharpIndex))) ||
-      (afterSharpCharCode === 63 /* '?' */ &&
-        fastStartsWithFrom(line, /* #?# */ '?#', afterSharpIndex))
+        (line.startsWith(/* #$# */ '$#', afterSharpIndex) ||
+          line.startsWith(/* #$?# */ '$?#', afterSharpIndex))) ||
+      (afterSharpCharCode === 63 /* '?' */ && line.startsWith(/* #?# */ '?#', afterSharpIndex))
     ) {
       if (extendedNonSupportedTypes) {
         return FilterType.NOT_SUPPORTED_ADGUARD;

--- a/packages/adblocker/src/utils.ts
+++ b/packages/adblocker/src/utils.ts
@@ -65,37 +65,6 @@ export function hashStrings(strings: string[]): Uint32Array {
   return result;
 }
 
-// https://jsperf.com/string-startswith/21
-export function fastStartsWith(haystack: string, needle: string): boolean {
-  if (haystack.length < needle.length) {
-    return false;
-  }
-
-  const ceil = needle.length;
-  for (let i = 0; i < ceil; i += 1) {
-    if (haystack[i] !== needle[i]) {
-      return false;
-    }
-  }
-
-  return true;
-}
-
-export function fastStartsWithFrom(haystack: string, needle: string, start: number): boolean {
-  if (haystack.length - start < needle.length) {
-    return false;
-  }
-
-  const ceil = start + needle.length;
-  for (let i = start; i < ceil; i += 1) {
-    if (haystack[i] !== needle[i - start]) {
-      return false;
-    }
-  }
-
-  return true;
-}
-
 export function isDigit(ch: number): boolean {
   // 48 == '0'
   // 57 == '9'


### PR DESCRIPTION
Fixes https://github.com/ghostery/adblocker/issues/4517.

Per benchmarks mentioned in the issue, `fastStartsWith` & `fastStartsWithFrom` are consistently slower on modern Chrome and modern Firefox (up to 0.5x to 1x slower).

All tests and lints passed locally on my machine.