### PR TITLE
fix: check domains validity when parsing network filters

### DIFF
--- a/packages/adblocker/src/engine/domains.ts
+++ b/packages/adblocker/src/engine/domains.ts
@@ -12,7 +12,9 @@ import { StaticDataView, sizeOfUint32Array, sizeOfUTF8 } from '../data-view.js';
 import { binLookup, hasUnicode, HASH_INTERNAL_MULT } from '../utils.js';
 
 export class Domains {
-  public static parse(parts: string[], delimiter: string, debug = false): Domains | undefined {
+  public static parse(value: string, delimiter: string, debug = false): Domains | undefined {
+    const parts = value.split(delimiter);
+
     if (parts.length === 0) {
       return undefined;
     }

--- a/packages/adblocker/src/engine/domains.ts
+++ b/packages/adblocker/src/engine/domains.ts
@@ -13,7 +13,13 @@ import { binLookup, hasUnicode, HASH_INTERNAL_MULT } from '../utils.js';
 
 export class Domains {
   public static parse(parts: string[], debug: boolean = false): Domains | undefined {
-    if (parts.length === 0) {
+    if (
+      parts.length === 0 ||
+      // We accept parts after splitting a string by `|`
+      // Empty first and last entry indicates it's invalid
+      parts[0].length === 0 ||
+      parts[parts.length - 1].length === 0
+    ) {
       return undefined;
     }
 

--- a/packages/adblocker/src/engine/domains.ts
+++ b/packages/adblocker/src/engine/domains.ts
@@ -12,22 +12,14 @@ import { StaticDataView, sizeOfUint32Array, sizeOfUTF8 } from '../data-view.js';
 import { binLookup, hasUnicode, HASH_INTERNAL_MULT } from '../utils.js';
 
 export class Domains {
-  public static parse(
-    parts: string[],
-    {
-      isNetworkEntities = false,
-      debug = false,
-    }: { isNetworkEntities?: boolean | undefined; debug?: boolean | undefined } = {},
-  ): Domains | undefined {
+  public static parse(parts: string[], delimiter = ',', debug = false): Domains | undefined {
     if (parts.length === 0) {
       return undefined;
     }
 
-    if (isNetworkEntities === true) {
-      for (const part of parts) {
-        if (part.length === 0 || part.startsWith('|') || part.endsWith('|')) {
-          return undefined;
-        }
+    for (const part of parts) {
+      if (part.length === 0 || part.startsWith(delimiter) || part.endsWith(delimiter)) {
+        return undefined;
       }
     }
 
@@ -73,7 +65,7 @@ export class Domains {
       hostnames: hostnames.length !== 0 ? new Uint32Array(hostnames).sort() : undefined,
       notEntities: notEntities.length !== 0 ? new Uint32Array(notEntities).sort() : undefined,
       notHostnames: notHostnames.length !== 0 ? new Uint32Array(notHostnames).sort() : undefined,
-      parts: debug === true ? parts.join(isNetworkEntities ? '|' : ',') : undefined,
+      parts: debug === true ? parts.join(delimiter) : undefined,
     });
   }
 

--- a/packages/adblocker/src/engine/domains.ts
+++ b/packages/adblocker/src/engine/domains.ts
@@ -12,7 +12,7 @@ import { StaticDataView, sizeOfUint32Array, sizeOfUTF8 } from '../data-view.js';
 import { binLookup, hasUnicode, HASH_INTERNAL_MULT } from '../utils.js';
 
 export class Domains {
-  public static parse(parts: string[], delimiter = ',', debug = false): Domains | undefined {
+  public static parse(parts: string[], delimiter: string, debug = false): Domains | undefined {
     if (parts.length === 0) {
       return undefined;
     }

--- a/packages/adblocker/src/engine/domains.ts
+++ b/packages/adblocker/src/engine/domains.ts
@@ -11,22 +11,18 @@ import { toASCII } from '../punycode.js';
 import { StaticDataView, sizeOfUint32Array, sizeOfUTF8 } from '../data-view.js';
 import { binLookup, hasUnicode, HASH_INTERNAL_MULT } from '../utils.js';
 
-export function normalizeNetworkEntities(parts: string[]) {
-  const newParts: string[] = [];
-
+export function testNetworkParts(parts: string[]): boolean {
   for (const part of parts) {
     if (part.length === 0) {
-      continue;
+      return false;
     } else if (part.startsWith('|')) {
-      newParts.push(part.slice(1));
+      return false;
     } else if (part.endsWith('|')) {
-      newParts.push(part.slice(0, -1));
-    } else {
-      newParts.push(part);
+      return false;
     }
   }
 
-  return newParts;
+  return true;
 }
 
 export function normalizeNetworkPartsLiteral(parts: string) {

--- a/packages/adblocker/src/engine/domains.ts
+++ b/packages/adblocker/src/engine/domains.ts
@@ -11,15 +11,29 @@ import { toASCII } from '../punycode.js';
 import { StaticDataView, sizeOfUint32Array, sizeOfUTF8 } from '../data-view.js';
 import { binLookup, hasUnicode, HASH_INTERNAL_MULT } from '../utils.js';
 
+export function normalizeNetworkEntities(parts: string[]) {
+  const newParts: string[] = [];
+
+  for (const part of parts) {
+    if (part.length === 0) {
+      continue;
+    } else if (part.startsWith('|')) {
+      newParts.push(part);
+    } else if (part.endsWith('|')) {
+      newParts.push(part);
+    }
+  }
+
+  return newParts;
+}
+
+export function normalizeNetworkPartsLiteral(parts: string) {
+  return parts.replace(/,/g, '|');
+}
+
 export class Domains {
   public static parse(parts: string[], debug: boolean = false): Domains | undefined {
-    if (
-      parts.length === 0 ||
-      // We accept parts after splitting a string by `|`
-      // Empty first and last entry indicates it's invalid
-      parts[0].length === 0 ||
-      parts[parts.length - 1].length === 0
-    ) {
+    if (parts.length === 0) {
       return undefined;
     }
 

--- a/packages/adblocker/src/engine/domains.ts
+++ b/packages/adblocker/src/engine/domains.ts
@@ -12,7 +12,10 @@ import { StaticDataView, sizeOfUint32Array, sizeOfUTF8 } from '../data-view.js';
 import { binLookup, hasUnicode, HASH_INTERNAL_MULT } from '../utils.js';
 
 export class Domains {
-  public static parse(value: string, delimiter: string, debug = false): Domains | undefined {
+  public static parse(
+    value: string,
+    { delimiter = ',', debug = false }: { delimiter?: string; debug?: boolean } = {},
+  ): Domains | undefined {
     const parts = value.split(delimiter);
 
     if (parts.length === 0) {

--- a/packages/adblocker/src/engine/domains.ts
+++ b/packages/adblocker/src/engine/domains.ts
@@ -11,28 +11,24 @@ import { toASCII } from '../punycode.js';
 import { StaticDataView, sizeOfUint32Array, sizeOfUTF8 } from '../data-view.js';
 import { binLookup, hasUnicode, HASH_INTERNAL_MULT } from '../utils.js';
 
-export function testNetworkParts(parts: string[]): boolean {
-  for (const part of parts) {
-    if (part.length === 0) {
-      return false;
-    } else if (part.startsWith('|')) {
-      return false;
-    } else if (part.endsWith('|')) {
-      return false;
-    }
-  }
-
-  return true;
-}
-
-export function normalizeNetworkPartsLiteral(parts: string) {
-  return parts.replace(/,/g, '|');
-}
-
 export class Domains {
-  public static parse(parts: string[], debug: boolean = false): Domains | undefined {
+  public static parse(
+    parts: string[],
+    {
+      isNetworkEntities = false,
+      debug = false,
+    }: { isNetworkEntities?: boolean | undefined; debug?: boolean | undefined } = {},
+  ): Domains | undefined {
     if (parts.length === 0) {
       return undefined;
+    }
+
+    if (isNetworkEntities === true) {
+      for (const part of parts) {
+        if (part.length === 0 || part.startsWith('|') || part.endsWith('|')) {
+          return undefined;
+        }
+      }
     }
 
     const entities: number[] = [];
@@ -77,7 +73,7 @@ export class Domains {
       hostnames: hostnames.length !== 0 ? new Uint32Array(hostnames).sort() : undefined,
       notEntities: notEntities.length !== 0 ? new Uint32Array(notEntities).sort() : undefined,
       notHostnames: notHostnames.length !== 0 ? new Uint32Array(notHostnames).sort() : undefined,
-      parts: debug === true ? parts.join(',') : undefined,
+      parts: debug === true ? parts.join(isNetworkEntities ? '|' : ',') : undefined,
     });
   }
 

--- a/packages/adblocker/src/engine/domains.ts
+++ b/packages/adblocker/src/engine/domains.ts
@@ -18,8 +18,10 @@ export function normalizeNetworkEntities(parts: string[]) {
     if (part.length === 0) {
       continue;
     } else if (part.startsWith('|')) {
-      newParts.push(part);
+      newParts.push(part.slice(1));
     } else if (part.endsWith('|')) {
+      newParts.push(part.slice(0, -1));
+    } else {
       newParts.push(part);
     }
   }

--- a/packages/adblocker/src/filters/cosmetic.ts
+++ b/packages/adblocker/src/filters/cosmetic.ts
@@ -263,7 +263,7 @@ export default class CosmeticFilter implements IFilter {
     // number of labels considered. This allows a compact representation of
     // hostnames and fast matching without any string copy.
     if (sharpIndex > 0) {
-      domains = Domains.parse(line.slice(0, sharpIndex).split(','), { debug });
+      domains = Domains.parse(line.slice(0, sharpIndex).split(','), ',', debug);
     }
 
     if (line.endsWith(':remove()')) {

--- a/packages/adblocker/src/filters/cosmetic.ts
+++ b/packages/adblocker/src/filters/cosmetic.ts
@@ -263,7 +263,7 @@ export default class CosmeticFilter implements IFilter {
     // number of labels considered. This allows a compact representation of
     // hostnames and fast matching without any string copy.
     if (sharpIndex > 0) {
-      domains = Domains.parse(line.slice(0, sharpIndex).split(','), debug);
+      domains = Domains.parse(line.slice(0, sharpIndex).split(','), { debug });
     }
 
     if (line.endsWith(':remove()')) {

--- a/packages/adblocker/src/filters/cosmetic.ts
+++ b/packages/adblocker/src/filters/cosmetic.ts
@@ -263,7 +263,7 @@ export default class CosmeticFilter implements IFilter {
     // number of labels considered. This allows a compact representation of
     // hostnames and fast matching without any string copy.
     if (sharpIndex > 0) {
-      domains = Domains.parse(line.slice(0, sharpIndex), ',', debug);
+      domains = Domains.parse(line.slice(0, sharpIndex), { debug });
     }
 
     if (line.endsWith(':remove()')) {

--- a/packages/adblocker/src/filters/cosmetic.ts
+++ b/packages/adblocker/src/filters/cosmetic.ts
@@ -263,7 +263,7 @@ export default class CosmeticFilter implements IFilter {
     // number of labels considered. This allows a compact representation of
     // hostnames and fast matching without any string copy.
     if (sharpIndex > 0) {
-      domains = Domains.parse(line.slice(0, sharpIndex).split(','), ',', debug);
+      domains = Domains.parse(line.slice(0, sharpIndex), ',', debug);
     }
 
     if (line.endsWith(':remove()')) {

--- a/packages/adblocker/src/filters/network.ts
+++ b/packages/adblocker/src/filters/network.ts
@@ -733,11 +733,17 @@ export default class NetworkFilter implements IFilter {
         switch (option) {
           case 'denyallow': {
             denyallow = Domains.parse(value.split('|'), '|', debug);
+            if (denyallow === undefined) {
+              return null;
+            }
             break;
           }
           case 'domain':
           case 'from': {
             domains = Domains.parse(value.split('|'), '|', debug);
+            if (domains === undefined) {
+              return null;
+            }
             break;
           }
           case 'badfilter':

--- a/packages/adblocker/src/filters/network.ts
+++ b/packages/adblocker/src/filters/network.ts
@@ -732,12 +732,12 @@ export default class NetworkFilter implements IFilter {
 
         switch (option) {
           case 'denyallow': {
-            denyallow = Domains.parse(value.split('|'), { isNetworkEntities: true, debug });
+            denyallow = Domains.parse(value.split('|'), '|', debug);
             break;
           }
           case 'domain':
           case 'from': {
-            domains = Domains.parse(value.split('|'), { isNetworkEntities: true, debug });
+            domains = Domains.parse(value.split('|'), '|', debug);
             break;
           }
           case 'badfilter':

--- a/packages/adblocker/src/filters/network.ts
+++ b/packages/adblocker/src/filters/network.ts
@@ -6,11 +6,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-import {
-  Domains,
-  normalizeNetworkEntities,
-  normalizeNetworkPartsLiteral,
-} from '../engine/domains.js';
+import { Domains, normalizeNetworkPartsLiteral, testNetworkParts } from '../engine/domains.js';
 import {
   StaticDataView,
   sizeOfNetworkFilter,
@@ -736,18 +732,20 @@ export default class NetworkFilter implements IFilter {
 
         switch (option) {
           case 'denyallow': {
-            denyallow = Domains.parse(normalizeNetworkEntities(value.split('|')), debug);
-            if (denyallow === undefined) {
+            const parts = value.split('|');
+            if (testNetworkParts(parts) === false) {
               return null;
             }
+            denyallow = Domains.parse(parts, debug);
             break;
           }
           case 'domain':
           case 'from': {
-            domains = Domains.parse(normalizeNetworkEntities(value.split('|')), debug);
-            if (domains === undefined) {
+            const parts = value.split('|');
+            if (testNetworkParts(parts) === false) {
               return null;
             }
+            domains = Domains.parse(parts, debug);
             break;
           }
           case 'badfilter':

--- a/packages/adblocker/src/filters/network.ts
+++ b/packages/adblocker/src/filters/network.ts
@@ -6,7 +6,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-import { Domains, normalizeNetworkPartsLiteral, testNetworkParts } from '../engine/domains.js';
+import { Domains } from '../engine/domains.js';
 import {
   StaticDataView,
   sizeOfNetworkFilter,
@@ -732,20 +732,12 @@ export default class NetworkFilter implements IFilter {
 
         switch (option) {
           case 'denyallow': {
-            const parts = value.split('|');
-            if (testNetworkParts(parts) === false) {
-              return null;
-            }
-            denyallow = Domains.parse(parts, debug);
+            denyallow = Domains.parse(value.split('|'), { isNetworkEntities: true, debug });
             break;
           }
           case 'domain':
           case 'from': {
-            const parts = value.split('|');
-            if (testNetworkParts(parts) === false) {
-              return null;
-            }
-            domains = Domains.parse(parts, debug);
+            domains = Domains.parse(value.split('|'), { isNetworkEntities: true, debug });
             break;
           }
           case 'badfilter':
@@ -1517,7 +1509,7 @@ export default class NetworkFilter implements IFilter {
 
     if (this.domains !== undefined) {
       if (this.domains.parts !== undefined) {
-        options.push(`domain=${normalizeNetworkPartsLiteral(this.domains.parts)}`);
+        options.push(`domain=${this.domains.parts}`);
       } else {
         options.push('domain=<hashed>');
       }
@@ -1525,7 +1517,7 @@ export default class NetworkFilter implements IFilter {
 
     if (this.denyallow !== undefined) {
       if (this.denyallow.parts !== undefined) {
-        options.push(`denyallow=${normalizeNetworkPartsLiteral(this.denyallow.parts)}`);
+        options.push(`denyallow=${this.denyallow.parts}`);
       } else {
         options.push('denyallow=<hashed>');
       }

--- a/packages/adblocker/src/filters/network.ts
+++ b/packages/adblocker/src/filters/network.ts
@@ -732,7 +732,7 @@ export default class NetworkFilter implements IFilter {
 
         switch (option) {
           case 'denyallow': {
-            denyallow = Domains.parse(value, '|', debug);
+            denyallow = Domains.parse(value, { delimiter: '|', debug });
             if (denyallow === undefined) {
               return null;
             }
@@ -740,7 +740,7 @@ export default class NetworkFilter implements IFilter {
           }
           case 'domain':
           case 'from': {
-            domains = Domains.parse(value, '|', debug);
+            domains = Domains.parse(value, { delimiter: '|', debug });
             if (domains === undefined) {
               return null;
             }

--- a/packages/adblocker/src/filters/network.ts
+++ b/packages/adblocker/src/filters/network.ts
@@ -1515,7 +1515,7 @@ export default class NetworkFilter implements IFilter {
 
     if (this.domains !== undefined) {
       if (this.domains.parts !== undefined) {
-        options.push(`domain=${this.domains.parts.split(',').join('|')}`);
+        options.push(`domain=${this.domains.parts.replace(/,/g, '|')}`);
       } else {
         options.push('domain=<hashed>');
       }
@@ -1523,7 +1523,7 @@ export default class NetworkFilter implements IFilter {
 
     if (this.denyallow !== undefined) {
       if (this.denyallow.parts !== undefined) {
-        options.push(`denyallow=${this.denyallow.parts.split(',').join('|')}`);
+        options.push(`denyallow=${this.denyallow.parts.replace(/,/g, '|')}`);
       } else {
         options.push('denyallow=<hashed>');
       }

--- a/packages/adblocker/src/filters/network.ts
+++ b/packages/adblocker/src/filters/network.ts
@@ -733,11 +733,17 @@ export default class NetworkFilter implements IFilter {
         switch (option) {
           case 'denyallow': {
             denyallow = Domains.parse(value.split('|'), debug);
+            if (domains === undefined) {
+              return null;
+            }
             break;
           }
           case 'domain':
           case 'from': {
             domains = Domains.parse(value.split('|'), debug);
+            if (domains === undefined) {
+              return null;
+            }
             break;
           }
           case 'badfilter':

--- a/packages/adblocker/src/filters/network.ts
+++ b/packages/adblocker/src/filters/network.ts
@@ -733,7 +733,7 @@ export default class NetworkFilter implements IFilter {
         switch (option) {
           case 'denyallow': {
             denyallow = Domains.parse(value.split('|'), debug);
-            if (domains === undefined) {
+            if (denyallow === undefined) {
               return null;
             }
             break;

--- a/packages/adblocker/src/filters/network.ts
+++ b/packages/adblocker/src/filters/network.ts
@@ -1515,7 +1515,7 @@ export default class NetworkFilter implements IFilter {
 
     if (this.domains !== undefined) {
       if (this.domains.parts !== undefined) {
-        options.push(`domain=${this.domains.parts}`);
+        options.push(`domain=${this.domains.parts.split(',').join('|')}`);
       } else {
         options.push('domain=<hashed>');
       }
@@ -1523,7 +1523,7 @@ export default class NetworkFilter implements IFilter {
 
     if (this.denyallow !== undefined) {
       if (this.denyallow.parts !== undefined) {
-        options.push(`denyallow=${this.denyallow.parts}`);
+        options.push(`denyallow=${this.denyallow.parts.split(',').join('|')}`);
       } else {
         options.push('denyallow=<hashed>');
       }

--- a/packages/adblocker/src/filters/network.ts
+++ b/packages/adblocker/src/filters/network.ts
@@ -732,7 +732,7 @@ export default class NetworkFilter implements IFilter {
 
         switch (option) {
           case 'denyallow': {
-            denyallow = Domains.parse(value.split('|'), '|', debug);
+            denyallow = Domains.parse(value, '|', debug);
             if (denyallow === undefined) {
               return null;
             }
@@ -740,7 +740,7 @@ export default class NetworkFilter implements IFilter {
           }
           case 'domain':
           case 'from': {
-            domains = Domains.parse(value.split('|'), '|', debug);
+            domains = Domains.parse(value, '|', debug);
             if (domains === undefined) {
               return null;
             }

--- a/packages/adblocker/src/filters/network.ts
+++ b/packages/adblocker/src/filters/network.ts
@@ -6,7 +6,11 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-import { Domains } from '../engine/domains.js';
+import {
+  Domains,
+  normalizeNetworkEntities,
+  normalizeNetworkPartsLiteral,
+} from '../engine/domains.js';
 import {
   StaticDataView,
   sizeOfNetworkFilter,
@@ -732,7 +736,7 @@ export default class NetworkFilter implements IFilter {
 
         switch (option) {
           case 'denyallow': {
-            denyallow = Domains.parse(value.split('|'), debug);
+            denyallow = Domains.parse(normalizeNetworkEntities(value.split('|')), debug);
             if (denyallow === undefined) {
               return null;
             }
@@ -740,7 +744,7 @@ export default class NetworkFilter implements IFilter {
           }
           case 'domain':
           case 'from': {
-            domains = Domains.parse(value.split('|'), debug);
+            domains = Domains.parse(normalizeNetworkEntities(value.split('|')), debug);
             if (domains === undefined) {
               return null;
             }
@@ -1515,7 +1519,7 @@ export default class NetworkFilter implements IFilter {
 
     if (this.domains !== undefined) {
       if (this.domains.parts !== undefined) {
-        options.push(`domain=${this.domains.parts.replace(/,/g, '|')}`);
+        options.push(`domain=${normalizeNetworkPartsLiteral(this.domains.parts)}`);
       } else {
         options.push('domain=<hashed>');
       }
@@ -1523,7 +1527,7 @@ export default class NetworkFilter implements IFilter {
 
     if (this.denyallow !== undefined) {
       if (this.denyallow.parts !== undefined) {
-        options.push(`denyallow=${this.denyallow.parts.replace(/,/g, '|')}`);
+        options.push(`denyallow=${normalizeNetworkPartsLiteral(this.denyallow.parts)}`);
       } else {
         options.push('denyallow=<hashed>');
       }

--- a/packages/adblocker/src/filters/network.ts
+++ b/packages/adblocker/src/filters/network.ts
@@ -737,14 +737,6 @@ export default class NetworkFilter implements IFilter {
           }
           case 'domain':
           case 'from': {
-            // domain list starting or ending with '|' is invalid
-            if (
-              value.charCodeAt(0) === 124 /* '|' */ ||
-              value.charCodeAt(value.length - 1) === 124 /* '|' */
-            ) {
-              return null;
-            }
-
             domains = Domains.parse(value.split('|'), debug);
             break;
           }

--- a/packages/adblocker/test/parsing.test.ts
+++ b/packages/adblocker/test/parsing.test.ts
@@ -15,6 +15,7 @@ import { parseFilters } from '../src/lists.js';
 import { hashStrings, tokenize } from '../src/utils.js';
 import { HTMLSelector, HTMLModifier } from '../src/html-filtering.js';
 import { NORMALIZED_TYPE_TOKEN, hashHostnameBackward } from '../src/request.js';
+import { Domains } from '../src/engine/domains.js';
 
 function h(hostnames: string[]): Uint32Array {
   return new Uint32Array(hostnames.map(hashHostnameBackward)).sort();
@@ -2645,6 +2646,14 @@ describe('scriptlets arguments parsing', () => {
       expect(CosmeticFilter.parse(`foo.com##+js(${scriptlet})`)?.parseScript(), scriptlet).to.eql(
         expected,
       );
+    }
+  });
+});
+
+describe('Domains', () => {
+  it('rejects to parse invalid pipes', () => {
+    for (const str of ['|foo.com', 'foo.com|', '|foo.com|']) {
+      expect(Domains.parse(str.split('|'))).to.be.undefined;
     }
   });
 });

--- a/packages/adblocker/test/parsing.test.ts
+++ b/packages/adblocker/test/parsing.test.ts
@@ -15,7 +15,7 @@ import { parseFilters } from '../src/lists.js';
 import { hashStrings, tokenize } from '../src/utils.js';
 import { HTMLSelector, HTMLModifier } from '../src/html-filtering.js';
 import { NORMALIZED_TYPE_TOKEN, hashHostnameBackward } from '../src/request.js';
-import { Domains, normalizeNetworkEntities } from '../src/engine/domains.js';
+import { normalizeNetworkEntities } from '../src/engine/domains.js';
 
 function h(hostnames: string[]): Uint32Array {
   return new Uint32Array(hostnames.map(hashHostnameBackward)).sort();
@@ -181,6 +181,9 @@ describe('Network filters', () => {
 
     it('pprint domain', () => {
       checkToString('ads$domain=foo.com|bar.co.uk|~baz.io', 'ads$domain=<hashed>');
+      checkToString('ads$domain=foo.com|bar.com', 'ads$domain=foo.com|bar.com', true);
+      checkToString('ads$denyallow=foo.com|bar.co.uk|~baz.io', 'ads$denyallow=<hashed>');
+      checkToString('ads$denyallow=foo.com|bar.com', 'ads$denyallow=foo.com|bar.com', true);
     });
 
     it('pprint with debug=true', () => {

--- a/packages/adblocker/test/parsing.test.ts
+++ b/packages/adblocker/test/parsing.test.ts
@@ -15,7 +15,6 @@ import { parseFilters } from '../src/lists.js';
 import { hashStrings, tokenize } from '../src/utils.js';
 import { HTMLSelector, HTMLModifier } from '../src/html-filtering.js';
 import { NORMALIZED_TYPE_TOKEN, hashHostnameBackward } from '../src/request.js';
-import { normalizeNetworkEntities } from '../src/engine/domains.js';
 
 function h(hostnames: string[]): Uint32Array {
   return new Uint32Array(hostnames.map(hashHostnameBackward)).sort();
@@ -2649,22 +2648,6 @@ describe('scriptlets arguments parsing', () => {
       expect(CosmeticFilter.parse(`foo.com##+js(${scriptlet})`)?.parseScript(), scriptlet).to.eql(
         expected,
       );
-    }
-  });
-});
-
-describe('Domains', () => {
-  context('#normalizeNetworkEntities', () => {
-    for (const [str, normalized] of [
-      ['|foo.com', 'foo.com'],
-      ['foo.com|', 'foo.com'],
-      ['|foo.com|', 'foo.com'],
-      ['foo.com|||', 'foo.com'],
-      ['foo.com|||||bar.com', 'foo.com|bar.com'],
-    ] as const satisfies [string, string][]) {
-      it(`corrects possible typo in domains: "${str}" to "${normalized}"`, () => {
-        expect(normalizeNetworkEntities(str.split('|')).join('|')).to.be.eql(normalized);
-      });
     }
   });
 });

--- a/packages/adblocker/test/parsing.test.ts
+++ b/packages/adblocker/test/parsing.test.ts
@@ -15,7 +15,7 @@ import { parseFilters } from '../src/lists.js';
 import { hashStrings, tokenize } from '../src/utils.js';
 import { HTMLSelector, HTMLModifier } from '../src/html-filtering.js';
 import { NORMALIZED_TYPE_TOKEN, hashHostnameBackward } from '../src/request.js';
-import { Domains } from '../src/engine/domains.js';
+import { Domains, normalizeNetworkEntities } from '../src/engine/domains.js';
 
 function h(hostnames: string[]): Uint32Array {
   return new Uint32Array(hostnames.map(hashHostnameBackward)).sort();
@@ -2651,9 +2651,17 @@ describe('scriptlets arguments parsing', () => {
 });
 
 describe('Domains', () => {
-  it('rejects to parse invalid pipes', () => {
-    for (const str of ['|foo.com', 'foo.com|', '|foo.com|']) {
-      expect(Domains.parse(str.split('|'))).to.be.undefined;
+  context('#normalizeNetworkEntities', () => {
+    for (const [str, normalized] of [
+      ['|foo.com', 'foo.com'],
+      ['foo.com|', 'foo.com'],
+      ['|foo.com|', 'foo.com'],
+      ['foo.com|||', 'foo.com'],
+      ['foo.com|||||bar.com', 'foo.com|bar.com'],
+    ] as const satisfies [string, string][]) {
+      it(`corrects possible typo in domains: "${str}" to "${normalized}"`, () => {
+        expect(normalizeNetworkEntities(str.split('|')).join('|')).to.be.eql(normalized);
+      });
     }
   });
 });


### PR DESCRIPTION
From https://github.com/ghostery/adblocker/pull/4524, I found that `NetworkFilter.prototype.toString` is broken for network modifiers utilizing `Domains`.

This fixes it by replacing all `,` into `|` in `Domains.parts`.

Also, this moves invalid option value check which was used to prevent passing `$domain=|a.com|` forms into `Domains.prototype.parse`.