### PR TITLE
fix: keep integrity in network filter mask

### DIFF
--- a/packages/adblocker/src/filters/network.ts
+++ b/packages/adblocker/src/filters/network.ts
@@ -969,11 +969,11 @@ export default class NetworkFilter implements IFilter {
     }
 
     if (cptMaskPositive === 0) {
-      mask = setBit(mask, cptMaskNegative);
+      mask |= cptMaskNegative;
     } else if (cptMaskNegative === FROM_ANY) {
-      mask = setBit(mask, cptMaskPositive);
+      mask |= cptMaskPositive;
     } else {
-      mask = setBit(mask, cptMaskPositive & cptMaskNegative);
+      mask |= cptMaskPositive & cptMaskNegative;
     }
 
     // Identify kind of pattern

--- a/packages/adblocker/src/filters/network.ts
+++ b/packages/adblocker/src/filters/network.ts
@@ -969,11 +969,11 @@ export default class NetworkFilter implements IFilter {
     }
 
     if (cptMaskPositive === 0) {
-      mask |= cptMaskNegative;
+      mask = setBit(mask, cptMaskNegative);
     } else if (cptMaskNegative === FROM_ANY) {
-      mask |= cptMaskPositive;
+      mask = setBit(mask, cptMaskPositive);
     } else {
-      mask |= cptMaskPositive & cptMaskNegative;
+      mask = setBit(mask, cptMaskPositive & cptMaskNegative);
     }
 
     // Identify kind of pattern

--- a/packages/adblocker/src/filters/network.ts
+++ b/packages/adblocker/src/filters/network.ts
@@ -1239,7 +1239,16 @@ export default class NetworkFilter implements IFilter {
   }) {
     this.filter = filter;
     this.hostname = hostname;
-    this.mask = mask;
+    // The >>> 0 (shifting by zero) does not actually shift the bits;
+    // instead, it triggers the conversion of x into a 32-bit unsigned integer.
+    // We use unsigned right shift with zero to ensure the integrity between
+    // runtime and serialized versions.
+    // `2147483648 | (1 << 30)` results `-1073741824` and it's still not a problem:
+    // `(-1073741824 >>> 24).toString(2)` results `'11000000'` and this indicates
+    // `StaticDataView.prototype.pushUint32` is also safe.
+    // However, it's always unsigned when an integer initialized using
+    // `StaticDataView.prototype.getUint32` and this will break the integrity.
+    this.mask = mask >>> 0;
     this.domains = domains;
     this.denyallow = denyallow;
     this.optionValue = optionValue;

--- a/packages/adblocker/src/filters/network.ts
+++ b/packages/adblocker/src/filters/network.ts
@@ -969,11 +969,11 @@ export default class NetworkFilter implements IFilter {
     }
 
     if (cptMaskPositive === 0) {
-      mask |= cptMaskNegative;
+      mask = setBit(mask, cptMaskNegative);
     } else if (cptMaskNegative === FROM_ANY) {
-      mask |= cptMaskPositive;
+      mask = setBit(mask, cptMaskPositive);
     } else {
-      mask |= cptMaskPositive & cptMaskNegative;
+      mask = setBit(mask, cptMaskPositive & cptMaskNegative);
     }
 
     // Identify kind of pattern
@@ -1239,16 +1239,7 @@ export default class NetworkFilter implements IFilter {
   }) {
     this.filter = filter;
     this.hostname = hostname;
-    // The >>> 0 (shifting by zero) does not actually shift the bits;
-    // instead, it triggers the conversion of x into a 32-bit unsigned integer.
-    // We use unsigned right shift with zero to ensure the integrity between
-    // runtime and serialized versions.
-    // `2147483648 | (1 << 30)` results `-1073741824` and it's still not a problem:
-    // `(-1073741824 >>> 24).toString(2)` results `'11000000'` and this indicates
-    // `StaticDataView.prototype.pushUint32` is also safe.
-    // However, it's always unsigned when an integer initialized using
-    // `StaticDataView.prototype.getUint32` and this will break the integrity.
-    this.mask = mask >>> 0;
+    this.mask = setBit(mask, 0);
     this.domains = domains;
     this.denyallow = denyallow;
     this.optionValue = optionValue;

--- a/packages/adblocker/src/utils.ts
+++ b/packages/adblocker/src/utils.ts
@@ -27,7 +27,7 @@ export function getBit(n: number, mask: number): boolean {
 }
 
 export function setBit(n: number, mask: number): number {
-  return (n | mask) >>> 0;
+  return n | mask;
 }
 
 export function clearBit(n: number, mask: number): number {

--- a/packages/adblocker/src/utils.ts
+++ b/packages/adblocker/src/utils.ts
@@ -31,7 +31,7 @@ export function setBit(n: number, mask: number): number {
 }
 
 export function clearBit(n: number, mask: number): number {
-  return n & ~mask;
+  return (n & ~mask) >>> 0;
 }
 
 export function fastHashBetween(str: string, begin: number, end: number): number {

--- a/packages/adblocker/src/utils.ts
+++ b/packages/adblocker/src/utils.ts
@@ -27,7 +27,7 @@ export function getBit(n: number, mask: number): boolean {
 }
 
 export function setBit(n: number, mask: number): number {
-  return n | mask;
+  return (n | mask) >>> 0;
 }
 
 export function clearBit(n: number, mask: number): number {

--- a/packages/adblocker/test/data-view.test.ts
+++ b/packages/adblocker/test/data-view.test.ts
@@ -136,6 +136,21 @@ describe('#StaticDataView', () => {
     });
   });
 
+  describe('#pushUint32', () => {
+    it('converts a signed integer into an unsigned integer', () => {
+      const view = StaticDataView.allocate(4, { enableCompression: false });
+      const mask = 1 << 31;
+      // Let's try to put "signed" 32nd bit after OR operation.
+      view.pushUint32(mask | (1 << 30));
+      // Since the `pos` is changed with `pushUint32`, it should be reset.
+      view.setPos(0);
+      // The view should return unsigned integer while keeping.
+      const n = view.getUint32();
+      expect(n).to.be.eql((mask | (1 << 30)) >>> 0);
+      expect(n.toString(2)).to.be.eql('11000000000000000000000000000000');
+    });
+  });
+
   describe('#getUint32ArrayView', () => {
     it('empty view', () => {
       const view = StaticDataView.allocate(0, { enableCompression: false });

--- a/packages/adblocker/test/data-view.test.ts
+++ b/packages/adblocker/test/data-view.test.ts
@@ -136,21 +136,6 @@ describe('#StaticDataView', () => {
     });
   });
 
-  describe('#pushUint32', () => {
-    it('converts a signed integer into an unsigned integer', () => {
-      const view = StaticDataView.allocate(4, { enableCompression: false });
-      const mask = 1 << 31;
-      // Let's try to put "signed" 32nd bit after OR operation.
-      view.pushUint32(mask | (1 << 30));
-      // Since the `pos` is changed with `pushUint32`, it should be reset.
-      view.setPos(0);
-      // The view should return unsigned integer while keeping.
-      const n = view.getUint32();
-      expect(n).to.be.eql((mask | (1 << 30)) >>> 0);
-      expect(n.toString(2)).to.be.eql('11000000000000000000000000000000');
-    });
-  });
-
   describe('#getUint32ArrayView', () => {
     it('empty view', () => {
       const view = StaticDataView.allocate(0, { enableCompression: false });

--- a/packages/adblocker/test/serialization.test.ts
+++ b/packages/adblocker/test/serialization.test.ts
@@ -74,7 +74,7 @@ describe('Serialization', () => {
     });
   });
 
-  describe.only('NetworkFilter', () => {
+  describe('NetworkFilter', () => {
     it('keeps integrity with the use of 32nd bit', () => {
       const buffer = StaticDataView.allocate(10, { enableCompression: false });
       const mask = (1 << 31) | (1 << 30);

--- a/packages/adblocker/test/serialization.test.ts
+++ b/packages/adblocker/test/serialization.test.ts
@@ -72,25 +72,21 @@ describe('Serialization', () => {
         checkFilterSerialization(NetworkFilter, networkFilters[i]);
       }
     });
-  });
 
-  describe('NetworkFilter', () => {
-    it('keeps integrity with the use of 32nd bit', () => {
-      const buffer = StaticDataView.allocate(10, { enableCompression: false });
-      const mask = (1 << 31) | (1 << 30);
-      const filter = new NetworkFilter({
-        filter: undefined,
-        hostname: undefined,
-        mask,
-        domains: undefined,
-        denyallow: undefined,
-        optionValue: undefined,
-        rawLine: undefined,
-        regex: undefined,
-      });
-      filter.serialize(buffer);
-      buffer.seekZero();
-      expect(NetworkFilter.deserialize(buffer)).to.be.eql(filter);
+    it('handles a filter mask with 32nd bit', () => {
+      checkFilterSerialization(
+        NetworkFilter,
+        new NetworkFilter({
+          filter: undefined,
+          hostname: undefined,
+          mask: 1 << 31,
+          domains: undefined,
+          denyallow: undefined,
+          optionValue: undefined,
+          rawLine: undefined,
+          regex: undefined,
+        }),
+      );
     });
   });
 

--- a/packages/adblocker/test/serialization.test.ts
+++ b/packages/adblocker/test/serialization.test.ts
@@ -74,6 +74,26 @@ describe('Serialization', () => {
     });
   });
 
+  describe.only('NetworkFilter', () => {
+    it('keeps integrity with the use of 32nd bit', () => {
+      const buffer = StaticDataView.allocate(10, { enableCompression: false });
+      const mask = (1 << 31) | (1 << 30);
+      const filter = new NetworkFilter({
+        filter: undefined,
+        hostname: undefined,
+        mask,
+        domains: undefined,
+        denyallow: undefined,
+        optionValue: undefined,
+        rawLine: undefined,
+        regex: undefined,
+      });
+      filter.serialize(buffer);
+      buffer.seekZero();
+      expect(NetworkFilter.deserialize(buffer)).to.be.eql(filter);
+    });
+  });
+
   describe('Engine', () => {
     it('fails with wrong version', () => {
       const engine = Engine.parse('||domain');

--- a/packages/adblocker/test/utils.test.ts
+++ b/packages/adblocker/test/utils.test.ts
@@ -19,6 +19,7 @@ import {
   fastHashBetween,
   findLastIndexOfUnescapedCharacter,
   hasUnicode,
+  setBit,
   tokenize,
   tokenizeInPlace,
   tokenizeNoSkip,
@@ -267,5 +268,19 @@ describe('utils.ts', () => {
   it('#findLastIndexOfUnescapedCharacter', () => {
     const line = String.raw`||www.youtube.com/playlist?list=$xhr,1p,replace=/("trackingParam":"kx_fmPxhoPZR)[-_0-9A-Za-z]{150}[-_0-9A-Za-z]+?([-_0-9A-Za-z]{55}lLKPQ-SS"\})/\$1\$2/`;
     expect(findLastIndexOfUnescapedCharacter(line, '$')).to.be.eql(32);
+  });
+
+  describe('#setBit', () => {
+    const lastBit = 1 << 31; // -2147483648
+
+    it('keeps the integer always unsigned', () => {
+      expect(setBit(0, lastBit)).to.be.greaterThan(0);
+      expect(setBit(0, lastBit)).to.be.eql(2147483648);
+    });
+    it('keeps all bit fields', () => {
+      const n = setBit(0, lastBit);
+      expect(setBit(n, 1 << 30) | (1 << 30)).to.be.eql(1073741824);
+      expect(setBit(n, 1 << 30) | lastBit).to.be.eql(lastBit);
+    });
   });
 });

--- a/packages/adblocker/test/utils.test.ts
+++ b/packages/adblocker/test/utils.test.ts
@@ -270,7 +270,6 @@ describe('utils.ts', () => {
     expect(findLastIndexOfUnescapedCharacter(line, '$')).to.be.eql(32);
   });
 
-  // `setBit` only does OR bit operation but this test reavels the use of 32nd bit is safe.
   describe('#setBit', () => {
     // The reason not to unsigned right shift with zero here is because it doens't affect to the AND operations.
     // A number after any bit operations is signed in JavaScript.
@@ -279,11 +278,10 @@ describe('utils.ts', () => {
 
     it('keeps the integer always unsigned', () => {
       const n = setBit(0, lastBit);
-      // The result should be negative 2147483648 (1 << 31) after the OR operation.
-      expect(n).to.be.eql(-2147483648);
-      // However, there's actually no change in the readable bit field.
+      // The result should be positive 2147483648 (1 << 31) after the OR operation.
+      expect(n).to.be.eql(2147483648);
       // The binary representation of the number should have a length of 32 with the first byte set.
-      expect((n >>> 0).toString(2)).to.be.eql('10000000000000000000000000000000');
+      expect(n.toString(2)).to.be.eql('10000000000000000000000000000000');
     });
     it('keeps all bit fields', () => {
       const n = setBit(0, lastBit);

--- a/packages/adblocker/test/utils.test.ts
+++ b/packages/adblocker/test/utils.test.ts
@@ -279,7 +279,7 @@ describe('utils.ts', () => {
     });
     it('keeps all bit fields', () => {
       const n = setBit(0, lastBit);
-      expect(setBit(n, 1 << 30) | (1 << 30)).to.be.eql(1073741824);
+      expect(setBit(n, 1 << 30) | (1 << 30)).to.be.eql(-1073741824);
       expect(setBit(n, 1 << 30) | lastBit).to.be.eql(lastBit);
     });
   });

--- a/packages/adblocker/test/utils.test.ts
+++ b/packages/adblocker/test/utils.test.ts
@@ -283,14 +283,5 @@ describe('utils.ts', () => {
       // The binary representation of the number should have a length of 32 with the first byte set.
       expect(n.toString(2)).to.be.eql('10000000000000000000000000000000');
     });
-    it('keeps all bit fields', () => {
-      const n = setBit(0, lastBit);
-      // AND operation should not be affected by using the 32nd bit and another bit (31st bit here).
-      // Therefore, the correctness of `getBit` after doing `setBit` with 32nd bit is ensured here.
-      expect(setBit(n, 1 << 30) & lastBit).to.be.eql(lastBit);
-      // Now, this emulates the situation after the parse or serialization of `NetworkFilter`: `n` is readonly unsigned.
-      // The result should be same, which ensures the correctness of `getBit`.
-      expect(setBit(n >>> 0, 1 << 30) & lastBit).to.be.eql(lastBit);
-    });
   });
 });

--- a/packages/adblocker/test/utils.test.ts
+++ b/packages/adblocker/test/utils.test.ts
@@ -15,6 +15,7 @@ import {
   HASH_SEED,
   binLookup,
   binSearch,
+  clearBit,
   fastHash,
   fastHashBetween,
   findLastIndexOfUnescapedCharacter,
@@ -270,18 +271,28 @@ describe('utils.ts', () => {
     expect(findLastIndexOfUnescapedCharacter(line, '$')).to.be.eql(32);
   });
 
-  describe('#setBit', () => {
+  context('bit operations', () => {
     // The reason not to unsigned right shift with zero here is because it doens't affect to the AND operations.
     // A number after any bit operations is signed in JavaScript.
     // If all of the bit fields are settled correctly, we see all numbers in signed state and having a signed number as a mask is fine.
     const lastBit = 1 << 31; // -2147483648
 
-    it('keeps the integer always unsigned', () => {
-      const n = setBit(0, lastBit);
-      // The result should be positive 2147483648 (1 << 31) after the OR operation.
-      expect(n).to.be.eql(2147483648);
-      // The binary representation of the number should have a length of 32 with the first byte set.
-      expect(n.toString(2)).to.be.eql('10000000000000000000000000000000');
+    describe('#setBit', () => {
+      it('keeps the integer always unsigned', () => {
+        const n = setBit(0, lastBit);
+        // The result should be positive 2147483648 (1 << 31) after the OR operation.
+        expect(n).to.be.eql(2147483648);
+        // The binary representation of the number should have a length of 32 with the first byte set.
+        expect(n.toString(2)).to.be.eql('10000000000000000000000000000000');
+      });
+    });
+
+    describe('#clearBit', () => {
+      it('keeps the integer always unsigned', () => {
+        const n = clearBit(lastBit, 0);
+        expect(n).to.be.eql(2147483648);
+        expect(n.toString(2)).to.be.eql('10000000000000000000000000000000');
+      });
     });
   });
 });


### PR DESCRIPTION
I'm marking this PR as `internal` since this change won't affect anything. This PR is to address and prevent unsafe bit operations in  https://github.com/ghostery/adblocker/pull/4528#discussion_r1926513791.