### PR TITLE
fix: cosmetic codebook generation

### DIFF
--- a/packages/adblocker/tools/generate_compression_codebooks.ts
+++ b/packages/adblocker/tools/generate_compression_codebooks.ts
@@ -130,7 +130,7 @@ async function generateCodebook(kind: string): Promise<string[]> {
   } else if (kind === 'raw-network') {
     options.maxNgram = 20;
   } else if (kind === 'cosmetic-selector') {
-    options.maxNgram = 90;
+    options.maxNgram = 89;
   }
   const codebook = generate(strings, options);
   validateCodebook(codebook, strings);


### PR DESCRIPTION
```
root@adblocker0:~/seia-adblocker-automatic-ngram-adjustment/packages/adblocker# yarn generate-codebooks
[INFO] Limiting maximum concurrency to "8"...
[WARN] Skipping automatic search for maximum "maxNgram" value as looking up pre-defined "maxNgram" value for the kind "network-csp" failed or the environment variable "CI" was not set!
[WARN] Skipping automatic search for maximum "maxNgram" value as looking up pre-defined "maxNgram" value for the kind "network-filter" failed or the environment variable "CI" was not set!
[WARN] Skipping automatic search for maximum "maxNgram" value as looking up pre-defined "maxNgram" value for the kind "network-redirect" failed or the environment variable "CI" was not set!
[WARN] Skipping automatic search for maximum "maxNgram" value as looking up pre-defined "maxNgram" value for the kind "network-hostname" failed or the environment variable "CI" was not set!
[INFO] Trying "maxNgram" of "90" for the kind "cosmetic-selector"...
[INFO] Trying "maxNgram" of "20" for the kind "raw-network"...
[INFO] Trying "maxNgram" of "19" for the kind "raw-cosmetic"...
[ERROR] Failed to generate codebook for the kind of "cosmetic-selector" with "maxNgram" of "90" Error: Command failed: tsx './tools/generate_compression_codebooks.ts' 'cosmetic-selector' '90'
file:///root/seia-adblocker-automatic-ngram-adjustment/node_modules/@remusao/counter/dist/esm/index.js:33
        this.map.set(key, this.get(key) + n);
                 ^

RangeError: Map maximum size exceeded
    at Map.set (<anonymous>)
    at Counter.incr (/root/seia-adblocker-automatic-ngram-adjustment/node_modules/@remusao/counter/src/index.ts:41:14)
    at addCounts (/root/seia-adblocker-automatic-ngram-adjustment/node_modules/@remusao/smaz-generate/src/index.ts:95:19)
    at generate (/root/seia-adblocker-automatic-ngram-adjustment/node_modules/@remusao/smaz-generate/src/index.ts:183:3)
    at generateCodebook (/root/seia-adblocker-automatic-ngram-adjustment/packages/adblocker/tools/generate_compression_codebooks.ts:132:20)
    at async <anonymous> (/root/seia-adblocker-automatic-ngram-adjustment/packages/adblocker/tools/generate_compression_codebooks.ts:151:20)

Node.js v22.13.0

    at genericNodeError (node:internal/errors:983:15)
    at wrappedFn (node:internal/errors:537:14)
    at ChildProcess.exithandler (node:child_process:414:12)
    at ChildProcess.emit (node:events:524:28)
    at maybeClose (node:internal/child_process:1101:16)
    at ChildProcess._handle.onexit (node:internal/child_process:304:5) {
  code: 1,
  killed: false,
  signal: null,
  cmd: "tsx './tools/generate_compression_codebooks.ts' 'cosmetic-selector' '90'",
  stdout: 'Generate codebook cosmetic-selector using 68110 strings.\n' +
    'Counting [1,90]-grams\n',
  stderr: 'file:///root/seia-adblocker-automatic-ngram-adjustment/node_modules/@remusao/counter/dist/esm/index.js:33\n' +
    '        this.map.set(key, this.get(key) + n);\n' +
    '                 ^\n' +
    '\n' +
    'RangeError: Map maximum size exceeded\n' +
    '    at Map.set (<anonymous>)\n' +
    '    at Counter.incr (/root/seia-adblocker-automatic-ngram-adjustment/node_modules/@remusao/counter/src/index.ts:41:14)\n' +
    '    at addCounts (/root/seia-adblocker-automatic-ngram-adjustment/node_modules/@remusao/smaz-generate/src/index.ts:95:19)\n' +
    '    at generate (/root/seia-adblocker-automatic-ngram-adjustment/node_modules/@remusao/smaz-generate/src/index.ts:183:3)\n' +
    '    at generateCodebook (/root/seia-adblocker-automatic-ngram-adjustment/packages/adblocker/tools/generate_compression_codebooks.ts:132:20)\n' +
    '    at async <anonymous> (/root/seia-adblocker-automatic-ngram-adjustment/packages/adblocker/tools/generate_compression_codebooks.ts:151:20)\n' +
    '\n' +
    'Node.js v22.13.0\n'
}
[INFO] Trying "maxNgram" of "89" for the kind "cosmetic-selector"...
```