### PR TITLE
fix(lint): @typescript-eslint/no-empty-object-type

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -31,7 +31,6 @@ export default tseslint.config(
       '@typescript-eslint/no-misused-promises': 'off',
       '@typescript-eslint/require-await': 'off',
       '@typescript-eslint/no-unused-vars': 'off',
-      '@typescript-eslint/no-empty-object-type': 'off',
     },
   },
   {

--- a/packages/adblocker-webextension/src/index.ts
+++ b/packages/adblocker-webextension/src/index.ts
@@ -321,7 +321,7 @@ export class BlockingContext {
   private readonly onRuntimeMessage: (
     msg: IBackgroundCallback & { action?: string },
     sender: Runtime.MessageSender,
-  ) => Promise<IMessageFromBackground | {}>;
+  ) => Promise<IMessageFromBackground | object>;
 
   private readonly onCommittedHandler:
     | ((details: WebNavigation.OnCommittedDetailsType) => void)
@@ -693,7 +693,7 @@ export class WebExtensionBlocker extends FiltersEngine {
     browser: Browser,
     msg: IBackgroundCallback & { action?: string },
     sender: Runtime.MessageSender,
-  ): Promise<IMessageFromBackground | {}> => {
+  ): Promise<IMessageFromBackground | object> => {
     return new Promise((resolve, reject) => {
       this.handleRuntimeMessage(browser, msg, sender, resolve)
         .catch(reject)


### PR DESCRIPTION
refs https://github.com/ghostery/adblocker/pull/4653/commits/cf4f19df0de1e71c2f9e4a1074679a3c980e21ab

Changed the type of `onRuntimeMessage` to `object` since we're still returning `{}` empty object in JavaScript. This can actually treated as an any object whose shape starts with empty object.