### PR TITLE
fix: remove `$to` support due to regression

### DIFF
--- a/packages/adblocker/src/engine/domains.ts
+++ b/packages/adblocker/src/engine/domains.ts
@@ -14,11 +14,7 @@ import { binLookup, hasUnicode, HASH_INTERNAL_MULT } from '../utils.js';
 export class Domains {
   public static parse(
     value: string,
-    {
-      delimiter = ',',
-      debug = false,
-      negate = false,
-    }: { delimiter?: string; debug?: boolean; negate?: boolean } = {},
+    { delimiter = ',', debug = false }: { delimiter?: string; debug?: boolean } = {},
   ): Domains | undefined {
     const parts = value.split(delimiter);
 
@@ -57,8 +53,7 @@ export class Domains {
         negation === true || entity === true ? hostname.slice(start, end) : hostname,
       );
 
-      // If conditionally negated value of `negation` by `negate` is `1`
-      if (+negation ^ +negate) {
+      if (negation) {
         if (entity) {
           notEntities.push(hash);
         } else {

--- a/packages/adblocker/src/filters/network.ts
+++ b/packages/adblocker/src/filters/network.ts
@@ -733,12 +733,10 @@ export default class NetworkFilter implements IFilter {
         const value = rawOption[1];
 
         switch (option) {
-          case 'to':
           case 'denyallow': {
             denyallow = Domains.parse(value, {
               delimiter: '|',
               debug,
-              negate: option === 'to',
             });
             if (denyallow === undefined) {
               return null;

--- a/packages/adblocker/test/matching.test.ts
+++ b/packages/adblocker/test/matching.test.ts
@@ -396,23 +396,6 @@ describe('#NetworkFilter.match', () => {
       url: 'https://sub.y.com/bar',
       type: 'script',
     });
-
-    // to
-    expect(f`*$3p,from=a.com,to=b.com`).to.matchRequest({
-      sourceUrl: 'https://a.com',
-      url: 'https://b.com/bar',
-      type: 'script',
-    });
-    expect(f`*$frame,3p,from=a.com|b.com,to=~c.com`).to.not.matchRequest({
-      sourceUrl: 'https://a.com',
-      url: 'https://c.com/bar',
-      type: 'sub_frame',
-    });
-    expect(f`$frame,csp=non-relevant,to=~safe.com,from=c.com|d.com`).to.not.matchRequest({
-      sourceUrl: 'https://c.com',
-      url: 'https://safe.com/foo',
-      type: 'sub_frame',
-    });
   });
 });
 

--- a/packages/adblocker/test/parsing.test.ts
+++ b/packages/adblocker/test/parsing.test.ts
@@ -806,29 +806,6 @@ describe('Network filters', () => {
           denyallow: undefined,
         });
       });
-
-      context('to', () => {
-        it('reverses domains condition', () => {
-          network('||foo.com$to=foo.com|~bar.com,denyallow=bar.com|~foo.com', {
-            denyallow: {
-              hostnames: h(['bar.com']),
-              entities: undefined,
-              notHostnames: h(['foo.com']),
-              notEntities: undefined,
-              parts: undefined,
-            },
-          });
-          network('||foo.com$to=bar.com|baz.com', {
-            denyallow: {
-              hostnames: undefined,
-              entities: undefined,
-              notHostnames: h(['bar.com', 'baz.com']),
-              notEntities: undefined,
-              parts: undefined,
-            },
-          });
-        });
-      });
     });
 
     describe('redirect', () => {


### PR DESCRIPTION
We noticed that `@@*$ghide,to=activo.mx|dynamicsupply.net|foroactivo.com|zdsports.org|~www.activo.mx|~www.foroactivo.com` filter was applied to `example.com` preventing cosmetic filters to be matched from https://github.com/ghostery/ghostery-extension/actions/runs/14589498756/job/40921286957?pr=2376. To quickly handle this, we plan to disable `$to` support first and revisit as soon as possible.

Besides the implementation error, I'm digging of other side-effects which are not revealed yet. I will try to confirm other functionalities of our ad-blocker as well. Try to support current unexpected behavior as a test case in the future.

For the future reference, I'm leaving some information here as of Apr 24, 2025:

```adb
###player-ads
```

disabled by:

```adb
@@*$ghide,to=activo.mx|dynamicsupply.net|foroactivo.com|zdsports.org|~www.activo.mx|~www.foroactivo.com
```

because `allowGenericHides` were set to `false` from `engine.js:774`.

```js
        if (allowGenericHides === true) {
            allowGenericHides = shouldApplyHideException(genericHides) === false;
        }
```

<details>
<summary>Details</summary>

```js
import { FiltersEngine } from '@ghostery/adblocker';
import fs from 'fs';
import path from 'path';

function getAllEnginePaths() {
  return fs
    .readdirSync('../src/rule_resources')
    .filter(function (file) {
      return file.endsWith('.dat');
    })
    .map(function (file) {
      return path.resolve('../src/rule_resources', file);
    });
}

function readAllEngines() {
  return getAllEnginePaths().map(function (location) {
    return FiltersEngine.deserialize(fs.readFileSync(location));
  });
}

function getMainEngine() {
  return FiltersEngine.merge(readAllEngines(), {
    skipResources: true,
    overrideConfig: {
      enableOptimizations: false,
    },
  });
}

const engine = getMainEngine();
const isBootstrap = false;
const url = 'https://example.com/';
const domain = 'example.com';
const hostname = 'example.com';
const config = {
  classes: [],
  hrefs: [],
  ids: ['player-ads'],
};

const filters = engine.getFilters().cosmeticFilters.filter(function (filter) {
  return (
    filter.selector.includes('player-ads') &&
    filter.mask === 16 &&
    filter.domains === undefined
  );
});
console.log(filters);

const updated = engine.update({
  removedNetworkFilters: [755478988],
});
console.log(updated);

const { matches } = engine.matchCosmeticFilters({
  domain,
  hostname,
  url,

  classes: config.classes,
  hrefs: config.hrefs,
  ids: config.ids,

  // This needs to be done only once per frame
  getInjectionRules: isBootstrap,
  getExtendedRules: isBootstrap,
  getRulesFromHostname: isBootstrap,

  getPureHasRules: true,

  // This will be done every time we get information about DOM mutation
  getRulesFromDOM: !isBootstrap,
});
console.log(matches);

```

</details>

refs https://github.com/ghostery/adblocker/pull/4524