### PR TITLE
feat: return filename in `BlockingResponse['redirect']`

### DIFF
--- a/packages/adblocker/package.json
+++ b/packages/adblocker/package.json
@@ -99,7 +99,7 @@
     }
   ],
   "devDependencies": {
-    "@remusao/smaz-generate": "^2.1.0",
+    "@remusao/smaz-generate": "^2.2.0",
     "@rollup/plugin-terser": "^0.4.4",
     "@types/chai": "^5.0.0",
     "@types/mocha": "^10.0.1",
@@ -120,9 +120,9 @@
   "dependencies": {
     "@ghostery/adblocker-content": "^2.5.2",
     "@ghostery/adblocker-extended-selectors": "^2.5.2",
-    "@remusao/guess-url-type": "^2.0.0",
-    "@remusao/small": "^2.0.0",
-    "@remusao/smaz": "^2.1.0",
+    "@remusao/guess-url-type": "^2.1.0",
+    "@remusao/small": "^2.1.0",
+    "@remusao/smaz": "^2.2.0",
     "tldts-experimental": "^7.0.0"
   }
 }

--- a/packages/adblocker/src/engine/engine.ts
+++ b/packages/adblocker/src/engine/engine.ts
@@ -75,7 +75,7 @@ export interface BlockingResponse {
   redirect:
     | undefined
     | {
-        name: string;
+        filename: string;
         body: string;
         contentType: string;
         dataUrl: string;

--- a/packages/adblocker/src/engine/engine.ts
+++ b/packages/adblocker/src/engine/engine.ts
@@ -75,6 +75,7 @@ export interface BlockingResponse {
   redirect:
     | undefined
     | {
+        name: string;
         body: string;
         contentType: string;
         dataUrl: string;

--- a/packages/adblocker/src/resources.ts
+++ b/packages/adblocker/src/resources.ts
@@ -298,7 +298,7 @@ export default class Resources {
   }
 
   public getResource(name: string): {
-    name: string;
+    filename: string;
     body: string;
     contentType: string;
     dataUrl: string;
@@ -317,7 +317,9 @@ export default class Resources {
       dataUrl = `data:${contentType};base64,${btoaPolyfill(body)}`;
     }
 
-    return { name, body, contentType, dataUrl };
+    // TODO: Direct response from `@remusao/small`
+    // refs https://github.com/remusao/mono/pull/869
+    return { filename: name, body, contentType, dataUrl };
   }
 
   public getScriptlet(name: string): string | undefined {

--- a/packages/adblocker/src/resources.ts
+++ b/packages/adblocker/src/resources.ts
@@ -305,8 +305,9 @@ export default class Resources {
   } {
     let resource:
       | {
-          body: string;
+          name: string;
           contentType: string;
+          body: string;
         }
       | undefined = this.resourcesByName.get(name);
     if (resource === undefined) {
@@ -315,20 +316,14 @@ export default class Resources {
     }
     const { contentType, body } = resource;
 
-    if ('name' in resource) {
-      name = (resource as Resource).name;
-    }
-
-    let dataUrl;
-    if (contentType.indexOf(';') !== -1) {
+    let dataUrl: string;
+    if (resource.contentType.indexOf(';') !== -1) {
       dataUrl = `data:${contentType},${body}`;
     } else {
       dataUrl = `data:${contentType};base64,${btoaPolyfill(body)}`;
     }
 
-    // TODO: Direct response from `@remusao/small`
-    // refs https://github.com/remusao/mono/pull/869
-    return { filename: name, body, contentType, dataUrl };
+    return { filename: resource.name, body, contentType, dataUrl };
   }
 
   public getScriptlet(name: string): string | undefined {

--- a/packages/adblocker/src/resources.ts
+++ b/packages/adblocker/src/resources.ts
@@ -297,8 +297,18 @@ export default class Resources {
     }
   }
 
-  public getResource(name: string): { body: string; contentType: string; dataUrl: string } {
-    const { body, contentType } = this.resourcesByName.get(name) || getResourceForMime(name);
+  public getResource(name: string): {
+    name: string;
+    body: string;
+    contentType: string;
+    dataUrl: string;
+  } {
+    const resource = this.resourcesByName.get(name) || getResourceForMime(name);
+    const { contentType, body } = resource;
+
+    if ('name' in resource) {
+      name = (resource as Resource).name;
+    }
 
     let dataUrl;
     if (contentType.indexOf(';') !== -1) {
@@ -307,7 +317,7 @@ export default class Resources {
       dataUrl = `data:${contentType};base64,${btoaPolyfill(body)}`;
     }
 
-    return { body, contentType, dataUrl };
+    return { name, body, contentType, dataUrl };
   }
 
   public getScriptlet(name: string): string | undefined {

--- a/packages/adblocker/src/resources.ts
+++ b/packages/adblocker/src/resources.ts
@@ -303,7 +303,16 @@ export default class Resources {
     contentType: string;
     dataUrl: string;
   } {
-    const resource = this.resourcesByName.get(name) || getResourceForMime(name);
+    let resource:
+      | {
+          body: string;
+          contentType: string;
+        }
+      | undefined = this.resourcesByName.get(name);
+    if (resource === undefined) {
+      const extensionIndex = name.lastIndexOf('.');
+      resource = getResourceForMime(extensionIndex === -1 ? name : name.slice(extensionIndex));
+    }
     const { contentType, body } = resource;
 
     if ('name' in resource) {

--- a/packages/adblocker/test/engine/engine.test.ts
+++ b/packages/adblocker/test/engine/engine.test.ts
@@ -435,6 +435,7 @@ $csp=baz,domain=bar.com
       expect(filter).not.to.be.undefined;
       expect((filter as NetworkFilter).toString()).to.equal('||foo.com$image,redirect=foo.js');
       expect(redirect).to.eql({
+        name: 'foo.js',
         body: 'foo.js',
         contentType: 'application/javascript',
         dataUrl: 'data:application/javascript;base64,Zm9vLmpz',
@@ -447,6 +448,7 @@ $csp=baz,domain=bar.com
         'foo.js',
       ).match(request);
       expect(redirect).to.eql({
+        name: 'foo.js',
         body: 'foo.js',
         contentType: 'application/javascript',
         dataUrl: 'data:application/javascript;base64,Zm9vLmpz',
@@ -463,6 +465,7 @@ $csp=baz,domain=bar.com
         'a.js',
       ).match(request);
       expect(redirect).to.eql({
+        name: 'a.js',
         body: 'a.js',
         contentType: 'application/javascript',
         dataUrl: 'data:application/javascript;base64,YS5qcw==',
@@ -475,6 +478,7 @@ $csp=baz,domain=bar.com
         'a.js',
       ).match(request);
       expect(redirect).to.eql({
+        name: 'a.js',
         body: 'a.js',
         contentType: 'application/javascript',
         dataUrl: 'data:application/javascript;base64,YS5qcw==',
@@ -504,6 +508,7 @@ $csp=baz,domain=bar.com
         '||foo.com$image,redirect-rule=foo.js',
       );
       expect(redirect).to.eql({
+        name: 'foo.js',
         body: 'foo.js',
         contentType: 'application/javascript',
         dataUrl: 'data:application/javascript;base64,Zm9vLmpz',
@@ -516,6 +521,7 @@ $csp=baz,domain=bar.com
         'foo.js',
       ).match(request);
       expect(redirect).to.eql({
+        name: 'foo.js',
         body: 'foo.js',
         contentType: 'application/javascript',
         dataUrl: 'data:application/javascript;base64,Zm9vLmpz',
@@ -533,6 +539,7 @@ $csp=baz,domain=bar.com
         'a.js',
       ).match(request);
       expect(redirect).to.eql({
+        name: 'a.js',
         body: 'a.js',
         contentType: 'application/javascript',
         dataUrl: 'data:application/javascript;base64,YS5qcw==',
@@ -549,6 +556,7 @@ $csp=baz,domain=bar.com
         'a.js',
       ).match(request);
       expect(redirect).to.eql({
+        name: 'a.js',
         body: 'a.js',
         contentType: 'application/javascript',
         dataUrl: 'data:application/javascript;base64,YS5qcw==',

--- a/packages/adblocker/test/engine/engine.test.ts
+++ b/packages/adblocker/test/engine/engine.test.ts
@@ -435,7 +435,7 @@ $csp=baz,domain=bar.com
       expect(filter).not.to.be.undefined;
       expect((filter as NetworkFilter).toString()).to.equal('||foo.com$image,redirect=foo.js');
       expect(redirect).to.eql({
-        name: 'foo.js',
+        filename: 'foo.js',
         body: 'foo.js',
         contentType: 'application/javascript',
         dataUrl: 'data:application/javascript;base64,Zm9vLmpz',
@@ -448,7 +448,7 @@ $csp=baz,domain=bar.com
         'foo.js',
       ).match(request);
       expect(redirect).to.eql({
-        name: 'foo.js',
+        filename: 'foo.js',
         body: 'foo.js',
         contentType: 'application/javascript',
         dataUrl: 'data:application/javascript;base64,Zm9vLmpz',
@@ -465,7 +465,7 @@ $csp=baz,domain=bar.com
         'a.js',
       ).match(request);
       expect(redirect).to.eql({
-        name: 'a.js',
+        filename: 'a.js',
         body: 'a.js',
         contentType: 'application/javascript',
         dataUrl: 'data:application/javascript;base64,YS5qcw==',
@@ -478,7 +478,7 @@ $csp=baz,domain=bar.com
         'a.js',
       ).match(request);
       expect(redirect).to.eql({
-        name: 'a.js',
+        filename: 'a.js',
         body: 'a.js',
         contentType: 'application/javascript',
         dataUrl: 'data:application/javascript;base64,YS5qcw==',
@@ -508,7 +508,7 @@ $csp=baz,domain=bar.com
         '||foo.com$image,redirect-rule=foo.js',
       );
       expect(redirect).to.eql({
-        name: 'foo.js',
+        filename: 'foo.js',
         body: 'foo.js',
         contentType: 'application/javascript',
         dataUrl: 'data:application/javascript;base64,Zm9vLmpz',
@@ -521,7 +521,7 @@ $csp=baz,domain=bar.com
         'foo.js',
       ).match(request);
       expect(redirect).to.eql({
-        name: 'foo.js',
+        filename: 'foo.js',
         body: 'foo.js',
         contentType: 'application/javascript',
         dataUrl: 'data:application/javascript;base64,Zm9vLmpz',
@@ -539,7 +539,7 @@ $csp=baz,domain=bar.com
         'a.js',
       ).match(request);
       expect(redirect).to.eql({
-        name: 'a.js',
+        filename: 'a.js',
         body: 'a.js',
         contentType: 'application/javascript',
         dataUrl: 'data:application/javascript;base64,YS5qcw==',
@@ -556,7 +556,7 @@ $csp=baz,domain=bar.com
         'a.js',
       ).match(request);
       expect(redirect).to.eql({
-        name: 'a.js',
+        filename: 'a.js',
         body: 'a.js',
         contentType: 'application/javascript',
         dataUrl: 'data:application/javascript;base64,YS5qcw==',

--- a/yarn.lock
+++ b/yarn.lock
@@ -950,10 +950,10 @@ __metadata:
   dependencies:
     "@ghostery/adblocker-content": "npm:^2.5.2"
     "@ghostery/adblocker-extended-selectors": "npm:^2.5.2"
-    "@remusao/guess-url-type": "npm:^2.0.0"
-    "@remusao/small": "npm:^2.0.0"
-    "@remusao/smaz": "npm:^2.1.0"
-    "@remusao/smaz-generate": "npm:^2.1.0"
+    "@remusao/guess-url-type": "npm:^2.1.0"
+    "@remusao/small": "npm:^2.1.0"
+    "@remusao/smaz": "npm:^2.2.0"
+    "@remusao/smaz-generate": "npm:^2.2.0"
     "@rollup/plugin-terser": "npm:^0.4.4"
     "@types/chai": "npm:^5.0.0"
     "@types/mocha": "npm:^10.0.1"
@@ -1903,14 +1903,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@remusao/guess-url-type@npm:^2.0.0":
+"@remusao/guess-url-type@npm:^2.1.0":
   version: 2.1.0
   resolution: "@remusao/guess-url-type@npm:2.1.0"
   checksum: 10/083acf99389b35995af15a785cbbeea09b2819c87ee4405812db68103a529b836b8b4c3750c73c96c70fe157258d43251ad140719fcf063ba213d54663235a91
   languageName: node
   linkType: hard
 
-"@remusao/small@npm:^2.0.0":
+"@remusao/small@npm:^2.1.0":
   version: 2.1.0
   resolution: "@remusao/small@npm:2.1.0"
   checksum: 10/4c2588591b8cca54f12a38976c8ad7b1754d6a474859e8a504c157f3c4664b39dffed344ecb929cd1d42093bc85921f9f44e478ae2df184e5cdc8eb07890dd95
@@ -1933,7 +1933,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@remusao/smaz-generate@npm:^2.1.0":
+"@remusao/smaz-generate@npm:^2.2.0":
   version: 2.2.0
   resolution: "@remusao/smaz-generate@npm:2.2.0"
   dependencies:
@@ -1943,7 +1943,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@remusao/smaz@npm:^2.1.0":
+"@remusao/smaz@npm:^2.2.0":
   version: 2.2.0
   resolution: "@remusao/smaz@npm:2.2.0"
   dependencies:


### PR DESCRIPTION
fixes https://github.com/ghostery/adblocker/issues/4882

This modifies `BlockingResponse['redirect']` to have `name` property to expose the name of resource. By doing this, the user is able to reference a proper web accessible resource URL to return.

On https://github.com/ghostery/broken-page-reports/issues/1350, `NS_ERROR_DOM_BAD_URI` errors are reported on redirected resources.