### PR TITLE
fix(internal): unreachable code

### DIFF
--- a/packages/adblocker/src/engine/domains.ts
+++ b/packages/adblocker/src/engine/domains.ts
@@ -23,7 +23,7 @@ export class Domains {
     }
 
     for (const part of parts) {
-      if (part.length === 0 || part.startsWith(delimiter) || part.endsWith(delimiter)) {
+      if (part.length === 0) {
         return undefined;
       }
     }


### PR DESCRIPTION
delimiter cannot present there due to `split` call.

https://github.com/ghostery/adblocker/compare/ghostery:d972ef1...seia-soto:d8dc27c