### PR TITLE
chore: remove `reviewers` field from dependabot def

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,5 @@ updates:
       interval: daily
       time: "04:00"
     open-pull-requests-limit: 99
-    reviewers:
-      - remusao
     labels:
       - "PR: Dependencies :nut_and_bolt:"


### PR DESCRIPTION
refs https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/