### PR TITLE
refactor: `:upward`

### DIFF
--- a/packages/adblocker-extended-selectors/src/eval.ts
+++ b/packages/adblocker-extended-selectors/src/eval.ts
@@ -295,7 +295,7 @@ function handleCompoundSelector(element: Element, selectors: AST[]): Element[] {
       }
     }
     // Check if the loop was completed
-    if (currentIndex === selectors.length && results.indexOf(element) === -1) {
+    if (currentIndex === selectors.length && !results.includes(element)) {
       results.push(element);
     }
   }

--- a/packages/adblocker-extended-selectors/src/eval.ts
+++ b/packages/adblocker-extended-selectors/src/eval.ts
@@ -191,15 +191,15 @@ function transpose(element: Element, selector: AST): [] | [Element] {
         return [];
       }
       const literalOrNumeric = stripsWrappingQuotes(selector.argument);
+      let number = parseInt(literalOrNumeric, 10);
       let parentElement: Element | null = element;
-      if (!Number.isInteger(literalOrNumeric)) {
+      if (!Number.isInteger(number)) {
         while ((parentElement = parentElement.parentElement) !== null) {
           if (parentElement.matches(literalOrNumeric)) {
             return [parentElement];
           }
         }
       } else {
-        let number = parseInt(literalOrNumeric, 10);
         if (number <= 0 || number >= 256) {
           return [];
         }

--- a/packages/adblocker-extended-selectors/src/eval.ts
+++ b/packages/adblocker-extended-selectors/src/eval.ts
@@ -191,15 +191,18 @@ function transpose(element: Element, selector: AST): [] | [Element] {
         return [];
       }
       const literalOrNumeric = stripsWrappingQuotes(selector.argument);
-      let number = parseInt(literalOrNumeric, 10);
       let parentElement: Element | null = element;
-      if (isNaN(number)) {
+      if (!Number.isInteger(literalOrNumeric)) {
         while ((parentElement = parentElement.parentElement) !== null) {
           if (parentElement.matches(literalOrNumeric)) {
             return [parentElement];
           }
         }
-      } else if (number > 0 && number < 256) {
+      } else {
+        let number = parseInt(literalOrNumeric, 10);
+        if (number <= 0 || number >= 256) {
+          return [];
+        }
         while ((parentElement = parentElement.parentElement) !== null) {
           if (--number === 0) {
             return [parentElement];


### PR DESCRIPTION
Clarifies the role of `handleCompoundSelector`, `matches`, and `querySelectorAll`. Also, introduce `transpose` for better readability.