### PR TITLE
fix(adblocker-extended-selector): `compound` with `complex`

### DIFF
--- a/packages/adblocker-extended-selectors/src/eval.ts
+++ b/packages/adblocker-extended-selectors/src/eval.ts
@@ -420,7 +420,10 @@ export function querySelectorAll(element: Element, selector: AST): Element[] {
 
   if (selector.type === 'pseudo-class') {
     const results: Element[] = [];
-    for (const subjective of [element, ...element.querySelectorAll('*')]) {
+    // This code is intended to be matched with `document.documentElement.querySelectorAll`.
+    // Since `document` is at the higher position rather `document.documentElement`,
+    // it can't select `html` for an instance.
+    for (const subjective of element.querySelectorAll('*')) {
       if (matches(subjective, selector) && !results.includes(subjective)) {
         results.push(subjective);
       }

--- a/packages/adblocker-extended-selectors/src/eval.ts
+++ b/packages/adblocker-extended-selectors/src/eval.ts
@@ -308,9 +308,9 @@ function transpose(element: Element, selector: AST): Element[] | null {
         return [];
       }
 
-      const argumnent = stripsWrappingQuotes(selector.argument);
+      const argument = stripsWrappingQuotes(selector.argument);
       let parentElement: Element | null = element;
-      let number = Number(argumnent);
+      let number = Number(argument);
 
       if (Number.isInteger(number)) {
         if (number <= 0 || number >= 256) {
@@ -323,7 +323,7 @@ function transpose(element: Element, selector: AST): Element[] | null {
         }
       } else {
         while ((parentElement = parentElement.parentElement) !== null) {
-          if (parentElement.matches(argumnent)) {
+          if (parentElement.matches(argument)) {
             return [parentElement];
           }
         }

--- a/packages/adblocker-extended-selectors/src/eval.ts
+++ b/packages/adblocker-extended-selectors/src/eval.ts
@@ -429,8 +429,10 @@ export function querySelectorAll(element: Element, selector: AST): Element[] {
     // Since `document` is at the higher position rather `document.documentElement`,
     // it can't select `html` for an instance.
     for (const subjective of element.querySelectorAll('*')) {
-      if (matches(subjective, selector) && !results.includes(subjective)) {
-        results.push(subjective);
+      for (const result of traverse(subjective, [selector])) {
+        if (!results.includes(result)) {
+          results.push(result);
+        }
       }
     }
     return results;

--- a/packages/adblocker-extended-selectors/src/eval.ts
+++ b/packages/adblocker-extended-selectors/src/eval.ts
@@ -379,10 +379,6 @@ export function querySelectorAll(element: Element, selector: AST): Element[] {
     selector.type === 'type' ||
     selector.type === 'attribute'
   ) {
-    // Try to support literal `html` selector with type of `type`.
-    // if (element instanceof HTMLHtmlElement && selector.content === 'html') {
-    //   return [element];
-    // }
     return Array.from(element.querySelectorAll(selector.content));
   }
 

--- a/packages/adblocker-extended-selectors/src/eval.ts
+++ b/packages/adblocker-extended-selectors/src/eval.ts
@@ -297,22 +297,6 @@ function handleComplexSelector(element: Element, selector: Complex): Element[] {
  * but currently it's for the convenience to match return type.
  */
 function transpose(element: Element, selector: AST): Element[] | null {
-  // The difference between `complex` handlers in `querySelectorAll` and `transpose` is nothing.
-  // However, it's also handled here to clarify and reduce complexity in the code flow.
-  // `querySelectorAll` is not used in `traverse` to avoid changing the subjective element unintentionally.
-  // Unlike this function, it assumes the subjective element to be guessed for other selectors.
-  // Also, we don't want to handle other selectors unless required as others are not *actually* transposable selectors.
-  // Since `traverse` assumes the subjective element to be the given element, we don't transpose to that.
-  // For an instance, type of `attribute` is to validate the subjective element has an `attribute`,
-  // not to select and transpose to the selector in a row.
-  // However, we want to do actual *transpose* not *match* with the selector type of `complex`
-  // as it could be mixed in the `compound` type selector and we want to move the target.
-  // e.g. This compound: `html>body` involes *transposing*, but not this compound: `html[lang*="en"]` (only *matching*).
-  // Therefore, this describes the behavior within the children nodes of the `compound` selector.
-  if (selector.type === 'complex') {
-    return handleComplexSelector(element, selector);
-  }
-
   if (selector.type === 'pseudo-class') {
     if (selector.name === 'upward') {
       if (selector.argument === undefined) {

--- a/packages/adblocker-extended-selectors/src/eval.ts
+++ b/packages/adblocker-extended-selectors/src/eval.ts
@@ -289,7 +289,7 @@ function handleComplexSelector(element: Element, selector: Complex): Element[] {
 }
 
 /**
- * Tranposes the given element with a selector.
+ * Transposes the given element with a selector.
  * @param element The subjective element
  * @param selector A selector
  * @returns An array with and without singular element; we may support transposing to multiple targets in the future

--- a/packages/adblocker-extended-selectors/src/eval.ts
+++ b/packages/adblocker-extended-selectors/src/eval.ts
@@ -239,52 +239,57 @@ function handleComplexSelector(element: Element, selector: Complex): Element[] {
   const selectors =
     selector.right.type === 'compound' ? selector.right.compound : [selector.right];
   const results: Element[] = [];
-  if (selector.combinator === ' ') {
-    // Look for all children *in any depth* of the all `leftElements` and filter them by `traversal`.
-    for (const leftElement of leftElements) {
-      for (const child of leftElement.querySelectorAll('*')) {
-        for (const result of traverse(child, selectors)) {
+  switch (selector.combinator) {
+    case ' ':
+      // Look for all children *in any depth* of the all `leftElements` and filter them by `traversal`.
+      for (const leftElement of leftElements) {
+        for (const child of leftElement.querySelectorAll('*')) {
+          for (const result of traverse(child, selectors)) {
+            if (!results.includes(result)) {
+              results.push(result);
+            }
+          }
+        }
+      }
+      break;
+    case '>':
+      // Look for all children of the all `leftElements` and filter them by `traversal`.
+      for (const leftElement of leftElements) {
+        for (const child of leftElement.children) {
+          for (const result of traverse(child, selectors)) {
+            if (!results.includes(result)) {
+              results.push(result);
+            }
+          }
+        }
+      }
+      break;
+    case '~':
+      // Look for all siblings of the all `leftElements` and filter them by `traversal`.
+      for (const leftElement of leftElements) {
+        let sibling: Element | null = leftElement;
+        while ((sibling = sibling.nextElementSibling) !== null) {
+          for (const result of traverse(sibling, selectors)) {
+            if (!results.includes(result)) {
+              results.push(result);
+            }
+          }
+        }
+      }
+      break;
+    case '+':
+      // Look for a next sibiling of the all `leftElements` and filter them by `traversal`.
+      for (const leftElement of leftElements) {
+        if (leftElement.nextElementSibling === null) {
+          continue;
+        }
+        for (const result of traverse(leftElement.nextElementSibling, selectors)) {
           if (!results.includes(result)) {
             results.push(result);
           }
         }
       }
-    }
-  } else if (selector.combinator === '+') {
-    // Look for a next sibiling of the all `leftElements` and filter them by `traversal`.
-    for (const leftElement of leftElements) {
-      if (leftElement.nextElementSibling === null) {
-        continue;
-      }
-      for (const result of traverse(leftElement.nextElementSibling, selectors)) {
-        if (!results.includes(result)) {
-          results.push(result);
-        }
-      }
-    }
-  } else if (selector.combinator === '>') {
-    // Look for all children of the all `leftElements` and filter them by `traversal`.
-    for (const leftElement of leftElements) {
-      for (const child of leftElement.children) {
-        for (const result of traverse(child, selectors)) {
-          if (!results.includes(result)) {
-            results.push(result);
-          }
-        }
-      }
-    }
-  } else if (selector.combinator === '~') {
-    // Look for all siblings of the all `leftElements` and filter them by `traversal`.
-    for (const leftElement of leftElements) {
-      let sibling: Element | null = leftElement;
-      while ((sibling = sibling.nextElementSibling) !== null) {
-        for (const result of traverse(sibling, selectors)) {
-          if (!results.includes(result)) {
-            results.push(result);
-          }
-        }
-      }
-    }
+      break;
   }
   return results;
 }

--- a/packages/adblocker-extended-selectors/src/eval.ts
+++ b/packages/adblocker-extended-selectors/src/eval.ts
@@ -343,26 +343,27 @@ function traverse(root: Element, selectors: AST[]): Element[] {
     return [];
   }
 
-  const traversals: Array<{ element: Element; index: number }> = [{ element: root, index: 0 }];
+  const traversals = [{ element: root, index: 0 }];
   const results: Element[] = [];
-  const selectorsCount = selectors.length;
 
   while (traversals.length) {
     const traversal = traversals.pop()!;
-    for (; traversal.index < selectorsCount; traversal.index++) {
-      const candidates = transpose(traversal.element, selectors[traversal.index]);
+    const { element } = traversal;
+    let { index } = traversal;
+    for (; index < selectors.length; index++) {
+      const candidates = transpose(element, selectors[index]);
       const isTransposeOperator = candidates !== null;
       if (isTransposeOperator) {
-        traversals.push(...candidates.map((element) => ({ element, index: traversal.index + 1 })));
+        traversals.push(...candidates.map((element) => ({ element, index: index + 1 })));
         break;
-      } else if (matches(traversal.element, selectors[traversal.index]) === false) {
+      } else if (matches(element, selectors[index]) === false) {
         // no maches found - stop processing the branch
         break;
       }
     }
     // Check if the loop was completed
-    if (traversal.index === selectors.length && !results.includes(traversal.element)) {
-      results.push(traversal.element);
+    if (index === selectors.length && !results.includes(element)) {
+      results.push(element);
     }
   }
 

--- a/packages/adblocker-extended-selectors/test/unit/eval.test.ts
+++ b/packages/adblocker-extended-selectors/test/unit/eval.test.ts
@@ -861,35 +861,93 @@ describe('eval', () => {
         testQuerySelectorAll('.lure:upward(.target)', html, ['.target']);
       });
 
-      context('combinators', () => {
-        it('combinator of ` `', () => {
-          testQuerySelectorAll('p :upward(1)', `<article><p><a/></p><p></p></article>`, [
-            'p:has(a)',
-          ]);
+      describe('combinators', () => {
+        context('combinator of ` `', () => {
+          it('should respect ` ` combinator before pseudo-selector', () => {
+            // `p`: Seek for all `p`
+            // ` `: Select every element has children
+            // `:upward(1)`: Look parent at depth of 1
+            testQuerySelectorAll(
+              'p :upward(1)',
+              `<article><p id="res"><a/></p><p></p></article>`,
+              ['#res'],
+            );
+
+            // `p`: Seek for all `p`
+            // ` `: Select every element has children
+            // `a`: Select every element has children of `a`
+            // `:upward(1)`: Look parent at depth of 1
+            testQuerySelectorAll(
+              'p a:upward(1)',
+              `<article><p id="res"><a/></p><p></p></article>`,
+              ['#res'],
+            );
+
+            // `p`: Seek for all `p`
+            // `:has(span)`: Select every element has `span`
+            // ` `: Select every element has children
+            // `:upward(1)`: Look parent at depth of 1
+            testQuerySelectorAll('p:has(span) :upward(1)', '<p id="res"><span/></p><p/>', [
+              '#res',
+            ]);
+
+            // `p`: Select every element is `p`
+            // `:upward(div)`: Look parent with tag name of `div`
+            // ` `: Select every children at any depth
+            // `:has(:upward(a))`: Select every element has children which can look parent with tag name of `a`
+            // - From (whitespace) combinator, we select "p", "a", and "span". However, "span" cannot be selected
+            //   because it doesn't have a child element, making `:has` ineffective
+            testQuerySelectorAll(
+              'p:upward(div) :has(:upward(a))',
+              [
+                '<article><div><p target><a target><span/></a></p></div><div><p/></div></article>',
+                '<article><div><p><a/></p></div><div><p/></div></article>',
+              ].join('\n'),
+              ['[target]'],
+            );
+          });
         });
 
-        it('combinator of `+`', () => {
-          testQuerySelectorAll(
-            'p+p:not(:has(a)):upward(1)',
-            `<article><p><a/></p><p></p></article>`,
-            ['article'],
-          );
+        context('combinator of `+`', () => {
+          it('should respect `+` combinator before pseudo-selector', () => {
+            // `p`: Seek for all `p`
+            // `+`: Select every next siblings
+            // `p:not(:has(a))`: Select every element is `p` but don't have children of `a`
+            // `:upward(1)`: Look parent at depth of 1
+            testQuerySelectorAll(
+              'p+p:not(:has(a)):upward(1)',
+              `<article id="res"><p><a/></p><p></p></article>`,
+              ['#res'],
+            );
+          });
         });
 
-        it('combinator of `>`', () => {
-          testQuerySelectorAll(
-            'article>p:not(:has(a)):upward(1)',
-            `<article><p><a/></p><p></p></article>`,
-            ['article'],
-          );
+        context('combinator of `>`', () => {
+          it('should respect `>` combinator before pseudo-selector', () => {
+            // `article`: Seek for all `article`
+            // `>`: Select every children at depth of 1
+            // `p:not(:has(a))`: Select every element is `p` but don't have children of `a`
+            // `:upward(1)`: Look parent at depth of 1
+            testQuerySelectorAll(
+              'article>p:not(:has(a)):upward(1)',
+              `<article id="res"><p><a/></p><p></p></article>`,
+              ['#res'],
+            );
+          });
         });
 
-        it('combinator of `~`', () => {
-          testQuerySelectorAll(
-            'p~p:not(:has(a)):upward(1)',
-            `<article><p><a/></p><p></p></article>`,
-            ['article'],
-          );
+        context('combinator of `~`', () => {
+          it('should respect `~` combinator before pseudo-selector', () => {
+            // `p`: Seek for all `p`
+            // `~`: Select every siblings
+            // `p:not(:has(a))`: Select every element is `p` but don't have children of `a`
+            // `:upward(1)`: Look parent at depth of 1
+            testQuerySelectorAll(
+              'p~p:not(:has(a)):upward(1)',
+              `<article id="res"><p><a/></p><p></p></article>`,
+              ['#res'],
+            );
+          });
         });
       });
     });

--- a/packages/adblocker-extended-selectors/test/unit/eval.test.ts
+++ b/packages/adblocker-extended-selectors/test/unit/eval.test.ts
@@ -870,9 +870,9 @@ describe('eval', () => {
             testQuerySelectorAll(
               'p :upward(1)',
               `<article>
-  <p id="res"><a /></p>
-  <p></p>
-</article>`,
+                <p id="res"><a></a></p>
+                <p></p>
+              </article>`,
               ['#res'],
             );
 
@@ -883,9 +883,9 @@ describe('eval', () => {
             testQuerySelectorAll(
               'p a:upward(1)',
               `<article>
-  <p id="res"><a /></p>
-  <p></p>
-</article>`,
+                <p id="res"><a></a></p>
+                <p></p>
+              </article>`,
               ['#res'],
             );
 
@@ -909,19 +909,19 @@ describe('eval', () => {
             testQuerySelectorAll(
               'p:upward(div) :has(:upward(a))',
               `<article>
-  <div>
-    <p id="res1">
-      <a id="res2"><span /></a>
-    </p>
-  </div>
-  <div><p /></div>
-</article>
-<article>
-  <div>
-    <p><a /></p>
-  </div>
-  <div><p /></div>
-</article>`,
+                <div>
+                  <p id="res1">
+                    <a id="res2"><span /></a>
+                  </p>
+                </div>
+                <div><p /></div>
+              </article>
+              <article>
+                <div>
+                  <p><a /></p>
+                </div>
+                <div><p /></div>
+              </article>`,
               ['#res1', '#res2'],
             );
           });
@@ -936,9 +936,9 @@ describe('eval', () => {
             testQuerySelectorAll(
               'p+p:not(:has(a)):upward(1)',
               `<article id="res">
-  <p><a /></p>
-  <p></p>
-</article>`,
+                <p><a></a></p>
+                <p></p>
+              </article>`,
               ['#res'],
             );
           });
@@ -953,9 +953,9 @@ describe('eval', () => {
             testQuerySelectorAll(
               'article>p:not(:has(a)):upward(1)',
               `<article id="res">
-  <p><a /></p>
-  <p></p>
-</article>`,
+                <p><a></a></p>
+                <p></p>
+              </article>`,
               ['#res'],
             );
           });
@@ -970,9 +970,9 @@ describe('eval', () => {
             testQuerySelectorAll(
               'p~p:not(:has(a)):upward(1)',
               `<article id="res">
-  <p><a /></p>
-  <p></p>
-</article>`,
+                <p><a></a></p>
+                <p></p>
+              </article>`,
               ['#res'],
             );
           });

--- a/packages/adblocker-extended-selectors/test/unit/eval.test.ts
+++ b/packages/adblocker-extended-selectors/test/unit/eval.test.ts
@@ -629,6 +629,15 @@ describe('eval', () => {
           ].join('\n'),
           ['#res'],
         );
+
+        testQuerySelectorAll(
+          `:has(.banner):not(html):not(body)`,
+          [
+            '<div>Do not select this div</div>',
+            '<div id="res">Select this div<span class="banner"></span></div>',
+          ].join('\n'),
+          ['#res'],
+        );
       });
 
       it('nested :has', () => {
@@ -671,6 +680,22 @@ describe('eval', () => {
     });
 
     describe(':not', () => {
+      it('not paragraph', () => {
+        testQuerySelectorAll(
+          ':not(p):not(body):not(html):not(head)',
+          [
+            '<!DOCTYPE html>',
+            '<head></head>',
+            '<body>',
+            '  <div id="res">',
+            '    <img id="res" alt="Foo">',
+            '  </div>',
+            '</body>',
+          ].join('\n'),
+          ['#res'],
+        );
+      });
+
       it('compound', () => {
         testQuerySelectorAll(
           'h2 :not(span.foo)',

--- a/packages/adblocker-extended-selectors/test/unit/eval.test.ts
+++ b/packages/adblocker-extended-selectors/test/unit/eval.test.ts
@@ -869,7 +869,10 @@ describe('eval', () => {
             // `:upward(1)`: Look parent at depth of 1
             testQuerySelectorAll(
               'p :upward(1)',
-              `<article><p id="res"><a/></p><p></p></article>`,
+              `<article>
+  <p id="res"><a /></p>
+  <p></p>
+</article>`,
               ['#res'],
             );
 
@@ -879,7 +882,10 @@ describe('eval', () => {
             // `:upward(1)`: Look parent at depth of 1
             testQuerySelectorAll(
               'p a:upward(1)',
-              `<article><p id="res"><a/></p><p></p></article>`,
+              `<article>
+  <p id="res"><a /></p>
+  <p></p>
+</article>`,
               ['#res'],
             );
 
@@ -887,9 +893,12 @@ describe('eval', () => {
             // `:has(span)`: Select every element has `span`
             // ` `: Select every element has children
             // `:upward(1)`: Look parent at depth of 1
-            testQuerySelectorAll('p:has(span) :upward(1)', '<p id="res"><span/></p><p/>', [
-              '#res',
-            ]);
+            testQuerySelectorAll(
+              'p:has(span) :upward(1)',
+              `<p id="res"><span /></p>
+<p />`,
+              ['#res'],
+            );
 
             // `p`: Select every element is `p`
             // `:upward(div)`: Look parent with tag name of `div`
@@ -899,11 +908,21 @@ describe('eval', () => {
             //   because it doesn't have a child element, making `:has` ineffective
             testQuerySelectorAll(
               'p:upward(div) :has(:upward(a))',
-              [
-                '<article><div><p target><a target><span/></a></p></div><div><p/></div></article>',
-                '<article><div><p><a/></p></div><div><p/></div></article>',
-              ].join('\n'),
-              ['[target]'],
+              `<article>
+  <div>
+    <p id="res1">
+      <a id="res2"><span /></a>
+    </p>
+  </div>
+  <div><p /></div>
+</article>
+<article>
+  <div>
+    <p><a /></p>
+  </div>
+  <div><p /></div>
+</article>`,
+              ['#res1', '#res2'],
             );
           });
         });
@@ -916,7 +935,10 @@ describe('eval', () => {
             // `:upward(1)`: Look parent at depth of 1
             testQuerySelectorAll(
               'p+p:not(:has(a)):upward(1)',
-              `<article id="res"><p><a/></p><p></p></article>`,
+              `<article id="res">
+  <p><a /></p>
+  <p></p>
+</article>`,
               ['#res'],
             );
           });
@@ -930,7 +952,10 @@ describe('eval', () => {
             // `:upward(1)`: Look parent at depth of 1
             testQuerySelectorAll(
               'article>p:not(:has(a)):upward(1)',
-              `<article id="res"><p><a/></p><p></p></article>`,
+              `<article id="res">
+  <p><a /></p>
+  <p></p>
+</article>`,
               ['#res'],
             );
           });
@@ -944,7 +969,10 @@ describe('eval', () => {
             // `:upward(1)`: Look parent at depth of 1
             testQuerySelectorAll(
               'p~p:not(:has(a)):upward(1)',
-              `<article id="res"><p><a/></p><p></p></article>`,
+              `<article id="res">
+  <p><a /></p>
+  <p></p>
+</article>`,
               ['#res'],
             );
           });

--- a/packages/adblocker-extended-selectors/test/unit/eval.test.ts
+++ b/packages/adblocker-extended-selectors/test/unit/eval.test.ts
@@ -854,6 +854,38 @@ describe('eval', () => {
         `;
         testQuerySelectorAll('.lure:upward(.target)', html, ['.target']);
       });
+
+      context('combinators', () => {
+        it('combinator of ` `', () => {
+          testQuerySelectorAll('p :upward(1)', `<article><p><a/></p><p></p></article>`, [
+            'p:has(a)',
+          ]);
+        });
+
+        it('combinator of `+`', () => {
+          testQuerySelectorAll(
+            'p+p:not(:has(a)):upward(1)',
+            `<article><p><a/></p><p></p></article>`,
+            ['article'],
+          );
+        });
+
+        it('combinator of `>`', () => {
+          testQuerySelectorAll(
+            'article>p:not(:has(a)):upward(1)',
+            `<article><p><a/></p><p></p></article>`,
+            ['article'],
+          );
+        });
+
+        it('combinator of `~`', () => {
+          testQuerySelectorAll(
+            'p~p:not(:has(a)):upward(1)',
+            `<article><p><a/></p><p></p></article>`,
+            ['article'],
+          );
+        });
+      });
     });
 
     describe(':has-text', () => {

--- a/packages/adblocker-extended-selectors/test/unit/eval.test.ts
+++ b/packages/adblocker-extended-selectors/test/unit/eval.test.ts
@@ -610,7 +610,7 @@ describe('eval', () => {
     describe(':has', () => {
       it('*:has', () => {
         testQuerySelectorAll(
-          `*:has(a[href^="https://"]):not(html):not(body):not(p)`,
+          `*:has(a[href^="https://"]):not(body):not(p)`,
           [
             '<!DOCTYPE html>',
             '<p class="cls1">',
@@ -637,7 +637,7 @@ describe('eval', () => {
         );
 
         testQuerySelectorAll(
-          `:has(.banner):not(html):not(body)`,
+          `:has(.banner):not(body)`,
           [
             '<div>Do not select this div</div>',
             '<div id="res">Select this div<span class="banner"></span></div>',
@@ -688,7 +688,7 @@ describe('eval', () => {
     describe(':not', () => {
       it('not paragraph', () => {
         testQuerySelectorAll(
-          ':not(p):not(body):not(html):not(head)',
+          ':not(p):not(body):not(head)',
           [
             '<!DOCTYPE html>',
             '<head></head>',

--- a/packages/adblocker-extended-selectors/test/unit/eval.test.ts
+++ b/packages/adblocker-extended-selectors/test/unit/eval.test.ts
@@ -629,15 +629,6 @@ describe('eval', () => {
           ].join('\n'),
           ['#res'],
         );
-
-        testQuerySelectorAll(
-          `:has(.banner):not(body)`,
-          [
-            '<div>Do not select this div</div>',
-            '<div id="res">Select this div<span class="banner"></span></div>',
-          ].join('\n'),
-          ['#res'],
-        );
       });
 
       it('nested :has', () => {
@@ -680,22 +671,6 @@ describe('eval', () => {
     });
 
     describe(':not', () => {
-      it('not paragraph', () => {
-        testQuerySelectorAll(
-          ':not(p):not(body):not(html):not(head)',
-          [
-            '<!DOCTYPE html>',
-            '<head></head>',
-            '<body>',
-            '  <div id="res">',
-            '    <img id="res" alt="Foo">',
-            '  </div>',
-            '</body>',
-          ].join('\n'),
-          ['#res'],
-        );
-      });
-
       it('compound', () => {
         testQuerySelectorAll(
           'h2 :not(span.foo)',

--- a/packages/adblocker-extended-selectors/test/unit/eval.test.ts
+++ b/packages/adblocker-extended-selectors/test/unit/eval.test.ts
@@ -527,6 +527,12 @@ describe('eval', () => {
   });
 
   describe('#querySelectorAll', () => {
+    context('deduplicates', () => {
+      it('type of `list`', () => {
+        testQuerySelectorAll('p>a,a', `<p><a/></p>`, ['a']);
+      });
+    });
+
     it('#id', () => {
       testQuerySelectorAll('#some_id', '<!DOCTYPE html><p id="some_id">Hello world</p>', [
         '#some_id',


### PR DESCRIPTION
Application of https://github.com/ghostery/adblocker/pull/4970 to the current version.

- Rename `handleCompoundSelector` with `traverse` as its job expands:
	* I decided to handle `compound` selectors specially per case
- Clarify the role of `querySelectorAll`
- Remove invalid test cases:
	* `:pseudo-class()` means the subjective element as the current element: defaults to `html`.
- Fix possible duplicate results in `querySelectorAll`
- Handle `compound` in `handleComplexSelector`