### PR TITLE
Adblocker: relax merge config consistancy check

### DIFF
--- a/packages/adblocker/src/engine/engine.ts
+++ b/packages/adblocker/src/engine/engine.ts
@@ -24,7 +24,7 @@ import { HTMLSelector } from '../html-filtering.js';
 import CosmeticFilter, { normalizeSelector } from '../filters/cosmetic.js';
 import NetworkFilter from '../filters/network.js';
 import { block } from '../filters/dsl.js';
-import { FilterType, IListDiff, IPartialRawDiff, parseFilters } from '../lists.js';
+import { f, FilterType, IListDiff, IPartialRawDiff, parseFilters } from '../lists.js';
 import Request from '../request.js';
 import Resources from '../resources.js';
 import CosmeticFilterBucket, { createStylesheet } from './bucket/cosmetic.js';
@@ -270,6 +270,14 @@ export default class FilterEngine extends EventEmitter<EngineEventHandlers> {
   ): InstanceType<T> {
     if (!engines || engines.length < 2) {
       throw new Error('merging engines requires at least two engines');
+    }
+
+    for (const engine of engines) {
+      if (engine.config.enableCompression !== engines[0].config.enableCompression) {
+        throw new Error(
+          `compression of all merged engines must match with the first one: "${engines[0].config.enableCompression}" but got: "${engine.config.enableCompression}"`,
+        );
+      }
     }
 
     const lists = new Map();

--- a/packages/adblocker/src/engine/engine.ts
+++ b/packages/adblocker/src/engine/engine.ts
@@ -24,7 +24,7 @@ import { HTMLSelector } from '../html-filtering.js';
 import CosmeticFilter, { normalizeSelector } from '../filters/cosmetic.js';
 import NetworkFilter from '../filters/network.js';
 import { block } from '../filters/dsl.js';
-import { f, FilterType, IListDiff, IPartialRawDiff, parseFilters } from '../lists.js';
+import { FilterType, IListDiff, IPartialRawDiff, parseFilters } from '../lists.js';
 import Request from '../request.js';
 import Resources from '../resources.js';
 import CosmeticFilterBucket, { createStylesheet } from './bucket/cosmetic.js';

--- a/packages/adblocker/src/engine/engine.ts
+++ b/packages/adblocker/src/engine/engine.ts
@@ -272,7 +272,6 @@ export default class FilterEngine extends EventEmitter<EngineEventHandlers> {
       throw new Error('merging engines requires at least two engines');
     }
 
-    const config = engines[0].config;
     const lists = new Map();
 
     const networkFilters: Map<number, NetworkFilter> = new Map();
@@ -289,29 +288,7 @@ export default class FilterEngine extends EventEmitter<EngineEventHandlers> {
       patterns: {},
     };
 
-    type ConfigKey = keyof {
-      [Key in keyof Config as Config[Key] extends boolean ? Key : never]: Config[Key];
-    };
-
-    const compatibleConfigKeys: ConfigKey[] = [];
-    const configKeysMustMatch: ConfigKey[] = (Object.keys(config) as (keyof Config)[]).filter(
-      function (key): key is ConfigKey {
-        return (
-          typeof config[key] === 'boolean' &&
-          !compatibleConfigKeys.includes(key as ConfigKey) &&
-          !Object.hasOwnProperty.call(overrideConfig, key)
-        );
-      },
-    );
-
     for (const engine of engines) {
-      // Validate the config
-      for (const configKey of configKeysMustMatch) {
-        if (config[configKey] !== engine.config[configKey]) {
-          throw new Error(`config "${configKey}" of all merged engines must be the same`);
-        }
-      }
-
       const filters = engine.getFilters();
 
       for (const networkFilter of filters.networkFilters) {
@@ -359,7 +336,7 @@ export default class FilterEngine extends EventEmitter<EngineEventHandlers> {
       preprocessors,
 
       lists,
-      config: new Config({ ...config, ...overrideConfig }),
+      config: new Config({ ...engines[0].config, ...overrideConfig }),
     }) as InstanceType<T>;
 
     if (

--- a/packages/adblocker/test/engine/engine.test.ts
+++ b/packages/adblocker/test/engine/engine.test.ts
@@ -2212,13 +2212,14 @@ foo.com###selector
     });
 
     context('configs', () => {
-      it('does not throw with different configs', () => {
+      it('does not throw with different configs - takes values from first', () => {
         const engine1 = FilterEngine.empty({ loadCosmeticFilters: true });
         const engine2 = FilterEngine.empty({ loadCosmeticFilters: false });
-        expect(() => FilterEngine.merge([engine1, engine2])).to.not.throw();
+        const engine = FilterEngine.merge([engine1, engine2]);
+        expect(engine.config).to.have.property('loadCosmeticFilters').that.equal(true);
       });
 
-      it('does throw if compression is different', () => {
+      it('throws on inconsistent compression', () => {
         const engine1 = FilterEngine.empty({ enableCompression: true });
         const engine2 = FilterEngine.empty({ enableCompression: false });
         expect(() => FilterEngine.merge([engine1, engine2])).to.throw(
@@ -2226,16 +2227,13 @@ foo.com###selector
         );
       });
 
-      it('allows to override the configs', () => {
+      it('allows config override', () => {
         const engine1 = FilterEngine.empty({ enableCompression: false });
         const engine2 = FilterEngine.empty({ enableCompression: false });
-        let engine: FilterEngine;
-        expect(() => {
-          engine = FilterEngine.merge([engine1, engine2], {
-            overrideConfig: { enableCompression: true },
-          });
-        }).not.to.throw();
-        expect(engine!.config).to.have.property('enableCompression').that.equal(true);
+        const engine = FilterEngine.merge([engine1, engine2], {
+          overrideConfig: { enableCompression: true },
+        });
+        expect(engine.config).to.have.property('enableCompression').that.equal(true);
       });
     });
 

--- a/packages/adblocker/test/engine/engine.test.ts
+++ b/packages/adblocker/test/engine/engine.test.ts
@@ -2211,25 +2211,23 @@ foo.com###selector
       });
     });
 
-    context('valides configs', () => {
-      it('throws with different configs', () => {
+    context('configs', () => {
+      it('does not throw with different configs', () => {
         const engine1 = FilterEngine.empty({ loadCosmeticFilters: true });
         const engine2 = FilterEngine.empty({ loadCosmeticFilters: false });
-        expect(() => FilterEngine.merge([engine1, engine2])).to.throw(
-          `config "loadCosmeticFilters" of all merged engines must be the same`,
-        );
+        expect(() => FilterEngine.merge([engine1, engine2])).to.not.throw();
       });
 
-      it('does not check overridden configs', () => {
-        const engine1 = FilterEngine.empty({ enableCompression: true });
+      it('allows to override the configs', () => {
+        const engine1 = FilterEngine.empty({ enableCompression: false });
         const engine2 = FilterEngine.empty({ enableCompression: false });
         let engine: FilterEngine;
         expect(() => {
           engine = FilterEngine.merge([engine1, engine2], {
-            overrideConfig: { enableCompression: false },
+            overrideConfig: { enableCompression: true },
           });
         }).not.to.throw();
-        expect(engine!.config).to.have.property('enableCompression').that.equal(false);
+        expect(engine!.config).to.have.property('enableCompression').that.equal(true);
       });
     });
 

--- a/packages/adblocker/test/engine/engine.test.ts
+++ b/packages/adblocker/test/engine/engine.test.ts
@@ -2218,6 +2218,14 @@ foo.com###selector
         expect(() => FilterEngine.merge([engine1, engine2])).to.not.throw();
       });
 
+      it('does throw if compression is different', () => {
+        const engine1 = FilterEngine.empty({ enableCompression: true });
+        const engine2 = FilterEngine.empty({ enableCompression: false });
+        expect(() => FilterEngine.merge([engine1, engine2])).to.throw(
+          'compression of all merged engines must match with the first one: "true" but got: "false"',
+        );
+      });
+
       it('allows to override the configs', () => {
         const engine1 = FilterEngine.empty({ enableCompression: false });
         const engine2 = FilterEngine.empty({ enableCompression: false });


### PR DESCRIPTION
Assumption that merge configs should be the same makes remote config updates impossible. In Ghostery extension we wanted to enable extended selectors, but pushing engines with this config enabled broke extensions as local engines (specifically custom filters) had a different config. 

This PR remove config consistency check, but still allows the client to control all flags. 