### PR TITLE
feat: export `Caching` type

### DIFF
--- a/packages/adblocker/src/index.ts
+++ b/packages/adblocker/src/index.ts
@@ -7,7 +7,7 @@
  */
 
 export { default as FiltersEngine, ENGINE_VERSION } from './engine/engine.js';
-export type { BlockingResponse } from './engine/engine.js';
+export type { BlockingResponse, Caching } from './engine/engine.js';
 export { default as ReverseIndex } from './engine/reverse-index.js';
 export {
   default as Request,


### PR DESCRIPTION
[`Caching`](https://github.com/ghostery/adblocker/blob/v2.11.2/packages/adblocker/src/engine/engine.ts#L94) is used by [`fromLists()`](https://github.com/ghostery/adblocker/blob/v2.11.2/packages/adblocker/src/engine/engine.ts#L167), but it's not exported.