### PR TITLE
Scriptlets: fix quote dropping

### DIFF
--- a/packages/adblocker/src/filters/cosmetic.ts
+++ b/packages/adblocker/src/filters/cosmetic.ts
@@ -795,8 +795,16 @@ export default class CosmeticFilter implements IFilter {
       .slice(1)
       .map((part) => {
         if (
-          (part.startsWith(`'`) && part.endsWith(`'`)) ||
-          (part.startsWith(`"`) && part.endsWith(`"`))
+          (part.startsWith(`'`) &&
+            part.endsWith(`'`) &&
+            part.length >= 2 &&
+            part.slice(1, -1).indexOf(`'`) === -1 &&
+            part.slice(1, -1).indexOf(',') === -1) ||
+          (part.startsWith(`"`) &&
+            part.endsWith(`"`) &&
+            part.length >= 2 &&
+            part.slice(1, -1).indexOf(`"`) === -1 &&
+            part.slice(1, -1).indexOf(',') === -1)
         ) {
           return part.substring(1, part.length - 1);
         }

--- a/packages/adblocker/src/filters/cosmetic.ts
+++ b/packages/adblocker/src/filters/cosmetic.ts
@@ -798,13 +798,13 @@ export default class CosmeticFilter implements IFilter {
           (part.startsWith(`'`) &&
             part.endsWith(`'`) &&
             part.length >= 2 &&
-            part.slice(1, -1).indexOf(`'`) === -1 &&
-            part.slice(1, -1).indexOf(',') === -1) ||
+            !part.slice(1, -1).match(/[^\\]'/) &&
+            !part.slice(1, -1).includes(',')) ||
           (part.startsWith(`"`) &&
             part.endsWith(`"`) &&
             part.length >= 2 &&
-            part.slice(1, -1).indexOf(`"`) === -1 &&
-            part.slice(1, -1).indexOf(',') === -1)
+            !part.slice(1, -1).match(/[^\\]"/) &&
+            !part.slice(1, -1).includes(','))
         ) {
           return part.substring(1, part.length - 1);
         }

--- a/packages/adblocker/test/parsing.test.ts
+++ b/packages/adblocker/test/parsing.test.ts
@@ -2423,6 +2423,39 @@ describe('scriptlets arguments parsing', () => {
 
   it('parses name with simple args', () => {
     for (const [scriptlet, expected] of [
+      [`simple, "quoted", 'single'`, { name: 'simple', args: ['quoted', 'single'] }],
+      [`test, "nested"quotes"inside"`, { name: 'test', args: [`"nested"quotes"inside"`] }],
+      [`test, 'nested'quotes'inside'`, { name: 'test', args: [`'nested'quotes'inside'`] }],
+      [`test, "no"internal"quotes"`, { name: 'test', args: [`"no"internal"quotes"`] }],
+      [`test, 'no'internal'quotes'`, { name: 'test', args: [`'no'internal'quotes'`] }],
+      [`test, "quoted,with,commas"`, { name: 'test', args: [`"quoted,with,commas"`] }],
+      [`test, 'quoted,with,commas'`, { name: 'test', args: [`'quoted,with,commas'`] }],
+      [`a, b, c`, { name: 'a', args: ['b', 'c'] }],
+      [`  a  ,  " b "  ,  c  `, { name: 'a', args: [' b ', 'c'] }],
+      [`test, "a,b", c, 'x,y'`, { name: 'test', args: [`"a,b"`, 'c', `'x,y'`] }],
+      [String.raw`test, a\,b, c\,d, e`, { name: 'test', args: ['a,b', 'c,d', 'e'] }],
+      [String.raw`test, "a\"b"", c`, { name: 'test', args: [String.raw`"a\"b""`, 'c'] }],
+      [`a,,b`, { name: 'a', args: ['', 'b'] }],
+      [
+        String.raw`trusted-replace-outbound-text, JSON.stringify, "params":", "params":"yAEB, condition, /("contentPlaybackContext":{".*\,"params":"|"params":".*"contentPlaybackContext":{")/`,
+        {
+          name: 'trusted-replace-outbound-text',
+          args: [
+            'JSON.stringify',
+            `"params":"`,
+            `"params":"yAEB`,
+            'condition',
+            `/("contentPlaybackContext":{".*,"params":"|"params":".*"contentPlaybackContext":{")/`,
+          ],
+        },
+      ],
+      [
+        `acs, decodeURIComponent, "'shift'"`,
+        {
+          name: 'acs',
+          args: ['decodeURIComponent', String.raw`'shift'`],
+        },
+      ],
       ['acs, $, adb', { name: 'acs', args: ['$', 'adb'] }],
       [
         'abort-current-script, document.createElement, break;case $.',

--- a/packages/adblocker/test/parsing.test.ts
+++ b/packages/adblocker/test/parsing.test.ts
@@ -2424,6 +2424,8 @@ describe('scriptlets arguments parsing', () => {
   it('parses name with simple args', () => {
     for (const [scriptlet, expected] of [
       [`simple, "quoted", 'single'`, { name: 'simple', args: ['quoted', 'single'] }],
+      [`test, 'John\\'s'`, { name: 'test', args: [`John\\'s`] }],
+      [`test, "John\\"s"`, { name: 'test', args: [`John\\"s`] }],
       [`test, "nested"quotes"inside"`, { name: 'test', args: [`"nested"quotes"inside"`] }],
       [`test, 'nested'quotes'inside'`, { name: 'test', args: [`'nested'quotes'inside'`] }],
       [`test, "no"internal"quotes"`, { name: 'test', args: [`"no"internal"quotes"`] }],


### PR DESCRIPTION
Previous logic of dropping quotes from scriplet argument was too aggressive and it was breaking production filters like:
```
www.youtube.com##+js(trusted-replace-outbound-text, JSON.stringify, "params":", "params":"yAEB, condition, /("contentPlaybackContext":{".*\,"params":"|"params":".*"contentPlaybackContext":{")/)


www.youtube.com##+js(trusted-replace-outbound-text, JSON.stringify, "contentCheckOk":false, "params":"yAEB"\,"contentCheckOk":false, condition, /^(?=.*"contentPlaybackContext":{")(?!.*"params":").*$/)
```

alternative for https://github.com/ghostery/adblocker/pull/5103


NOTE: When comparing with uBO parser, we found another edge case with commas in the quotes like `"a,b,c"` which we did not parse correctly. But I cannot find filters that would be affected by that problem. 