### PR TITLE
fix: scriptlet parsing with escaped ending quote

### DIFF
--- a/packages/adblocker/src/filters/cosmetic.ts
+++ b/packages/adblocker/src/filters/cosmetic.ts
@@ -814,6 +814,10 @@ export default class CosmeticFilter implements IFilter {
         ) {
           return part;
         }
+        // Passthrough `part` if it ends with escaped quote
+        if (part.charCodeAt(part.length - 2) === 92 /* '\\' */) {
+          return part;
+        }
         // Passthrough `part` if it contains unescaped quote
         if (part.length > 2) {
           for (let i = 1; i < part.length - 1; i++) {

--- a/packages/adblocker/test/parsing.test.ts
+++ b/packages/adblocker/test/parsing.test.ts
@@ -2580,10 +2580,9 @@ describe('scriptlets arguments parsing', () => {
         [`foo.com##+js(a, \\"value")`, [`\\"value"`]],
         [`foo.com##+js(a, \\'value')`, [`\\'value'`]],
         ['foo.com##+js(a, \\`value`)', ['\\`value`']],
-        // TODO: handle escaping character before closing quote
-        // [`foo.com##+js(a, "value\\")`, [`"value\\"`]],
-        // [`foo.com##+js(a, 'value\\')`, [`'value\\'`]],
-        // ['foo.com##+js(a, `value\\`)', ['`value\\`']],
+        [`foo.com##+js(a, "value\\")`, [`"value\\"`]],
+        [`foo.com##+js(a, 'value\\')`, [`'value\\'`]],
+        ['foo.com##+js(a, `value\\`)', ['`value\\`']],
         // TODO: backslash is not removed in case not required
         // > example.com##+js(rpnt, #text, Example Domain, "'value'\,'another'", condition, Example, stay, 1)
         // [`foo.com##+js(a, "va\\,lue")`, [`va\\,lue`]],


### PR DESCRIPTION
refs https://github.com/ghostery/adblocker/issues/5113

This pull request manually checks if there's an escaped quoting character at the end.