### PR TITLE
fix: improve scriptlet argument parsing for escaped commas objects

### DIFF
--- a/packages/adblocker/src/filters/cosmetic.ts
+++ b/packages/adblocker/src/filters/cosmetic.ts
@@ -803,7 +803,7 @@ export default class CosmeticFilter implements IFilter {
         inArgument = false;
       }
 
-      lastCharIsBackslash = char === '\\';
+      lastCharIsBackslash = char === '\\' && !lastCharIsBackslash;
     }
 
     parts.push(selector.slice(lastComaIndex + 1).trim());
@@ -840,8 +840,6 @@ export default class CosmeticFilter implements IFilter {
         return escaped.replace(REGEXP_ESCAPED_BACKTICK, '`');
       })
       .map((part) => {
-        // Only convert escaped commas that are NOT inside object literals
-        // Object literals are detected by checking if the part starts with '{'
         const isObjectLiteral = part.trim().startsWith('{');
         let result = part
           .replace(REGEXP_UNICODE_COMMA, ',')

--- a/packages/adblocker/src/filters/cosmetic.ts
+++ b/packages/adblocker/src/filters/cosmetic.ts
@@ -786,22 +786,27 @@ export default class CosmeticFilter implements IFilter {
               inArgument = true;
             }
           }
-          if (char === ',') {
-            parts.push(selector.slice(lastComaIndex + 1, index).trim());
-            lastComaIndex = index;
-            inArgument = false;
-          }
         }
+      }
+
+      // Split on comma only if not inside quotes, regexp, and not escaped
+      if (
+        lastCharIsBackslash === false &&
+        char === ',' &&
+        inDoubleQuotes === false &&
+        inSingleQuotes === false &&
+        inBackticks === false &&
+        inRegexp === false
+      ) {
+        parts.push(selector.slice(lastComaIndex + 1, index).trim());
+        lastComaIndex = index;
+        inArgument = false;
       }
 
       lastCharIsBackslash = char === '\\';
     }
 
     parts.push(selector.slice(lastComaIndex + 1).trim());
-
-    if (parts.length === 0) {
-      return undefined;
-    }
 
     const args = parts
       .slice(1)
@@ -834,12 +839,20 @@ export default class CosmeticFilter implements IFilter {
         }
         return escaped.replace(REGEXP_ESCAPED_BACKTICK, '`');
       })
-      .map((part) =>
-        part
+      .map((part) => {
+        // Only convert escaped commas that are NOT inside object literals
+        // Object literals are detected by checking if the part starts with '{'
+        const isObjectLiteral = part.trim().startsWith('{');
+        let result = part
           .replace(REGEXP_UNICODE_COMMA, ',')
-          .replace(REGEXP_UNICODE_BACKSLASH, '\\')
-          .replace(REGEXP_ESCAPED_COMMA, ','),
-      );
+          .replace(REGEXP_UNICODE_BACKSLASH, '\\');
+
+        if (!isObjectLiteral) {
+          result = result.replace(REGEXP_ESCAPED_COMMA, ',');
+        }
+
+        return result;
+      });
 
     this.scriptletDetails = { name: parts[0], args };
 

--- a/packages/adblocker/src/filters/cosmetic.ts
+++ b/packages/adblocker/src/filters/cosmetic.ts
@@ -840,7 +840,7 @@ export default class CosmeticFilter implements IFilter {
         return escaped.replace(REGEXP_ESCAPED_BACKTICK, '`');
       })
       .map((part) => {
-        const isObjectLiteral = part.trim().startsWith('{');
+        const isObjectLiteral = part.startsWith('{');
         let result = part
           .replace(REGEXP_UNICODE_COMMA, ',')
           .replace(REGEXP_UNICODE_BACKSLASH, '\\');

--- a/packages/adblocker/test/parsing.test.ts
+++ b/packages/adblocker/test/parsing.test.ts
@@ -2440,9 +2440,10 @@ describe('Scriptlet argument parsing', () => {
         ],
         ['aeld, mousedown, !!{});', { name: 'aeld', args: ['mousedown', '!!{});'] }],
       ] as const) {
-        expect(CosmeticFilter.parse(`foo.com##+js(${scriptlet})`)?.parseScript(), scriptlet).to.eql(
-          expected,
-        );
+        expect(
+          CosmeticFilter.parse(`foo.com##+js(${scriptlet})`)?.parseScript(),
+          scriptlet,
+        ).to.eql(expected);
       }
     });
 
@@ -2726,7 +2727,7 @@ describe('Scriptlet argument parsing', () => {
     it('handles escaped commas with quoted strings', () => {
       expect(
         CosmeticFilter.parse(
-          `www.youtube.com##+js(trusted-replace-outbound-text, JSON.stringify, "params":"yAEB, condition, /("contentPlaybackContext":{".*\\,"params":"|"params":".*"contentPlaybackContext":{")/)`
+          `www.youtube.com##+js(trusted-replace-outbound-text, JSON.stringify, "params":"yAEB, condition, /("contentPlaybackContext":{".*\\,"params":"|"params":".*"contentPlaybackContext":{")/)`,
         )?.parseScript(),
       ).to.eql({
         name: 'trusted-replace-outbound-text',
@@ -2742,7 +2743,7 @@ describe('Scriptlet argument parsing', () => {
     it('handles complex real-world examples', () => {
       expect(
         CosmeticFilter.parse(
-          String.raw`www.youtube.com##+js(trusted-replace-outbound-text, JSON.stringify, {"contentPlaybackContext", {"adPlaybackContext":{"pyv":true}\,"contentPlaybackContext", condition, currentUrl":"/watch)`
+          String.raw`www.youtube.com##+js(trusted-replace-outbound-text, JSON.stringify, {"contentPlaybackContext", {"adPlaybackContext":{"pyv":true}\,"contentPlaybackContext", condition, currentUrl":"/watch)`,
         )?.parseScript(),
       ).to.eql({
         name: 'trusted-replace-outbound-text',

--- a/packages/adblocker/test/parsing.test.ts
+++ b/packages/adblocker/test/parsing.test.ts
@@ -2408,10 +2408,10 @@ describe('Filters list', () => {
 
 describe('scriptlets arguments parsing', () => {
   it('parses empty argument list', () => {
-    const filter = CosmeticFilter.parse('foo.com#@#+js()');
+    const filter = CosmeticFilter.parse('foo.com#@#+js()')!;
     expect(filter).to.not.be.null;
-    expect(filter?.isScriptInject()).to.be.true;
-    expect(filter?.parseScript()).to.be.undefined;
+    expect(filter.isScriptInject()).to.be.true;
+    expect(filter.parseScript()).to.be.undefined;
   });
 
   it('parses name without args', () => {
@@ -2709,11 +2709,22 @@ describe('scriptlets arguments parsing', () => {
           ],
         ],
         [
-          `www.youtube.com##+js(trusted-replace-outbound-text, JSON.stringify, {"contentPlaybackContext", {"adPlaybackContext":{"pyv":true}\\,"contentPlaybackContext", condition, currentUrl":"/watch))`,
+          String.raw`www.youtube.com##+js(trusted-replace-outbound-text, JSON.stringify, {"contentPlaybackContext", {"adPlaybackContext":{"pyv":true}\,"contentPlaybackContext", condition, currentUrl":"/watch)`,
           [
             `JSON.stringify`,
             `{"contentPlaybackContext"`,
-            `{"adPlaybackContext":{"pyv":true}\\,"contentPlaybackContext"`,
+            String.raw`{"adPlaybackContext":{"pyv":true}\,"contentPlaybackContext"`,
+            `condition`,
+            `currentUrl":"/watch`,
+          ],
+        ],
+        [
+          String.raw`www.youtube.com##+js(trusted-replace-outbound-text, JSON.stringify, {"contentPlaybackContext", {"adPlaybackContext":{"pyv":true}\\,"contentPlaybackContext", condition, currentUrl":"/watch))`,
+          [
+            `JSON.stringify`,
+            `{"contentPlaybackContext"`,
+            String.raw`{"adPlaybackContext":{"pyv":true}\\`,
+            `contentPlaybackContext`,
             `condition`,
             `currentUrl":"/watch)`,
           ],


### PR DESCRIPTION
Enhances the `parseScript()` function to properly handle edge cases in scriptlet argument parsing:

  - Escaped commas: Arguments containing `,` are no longer incorrectly split at the escaped comma
  - Object literals: Clarifies that object literals must be wrapped in quotes (e.g., `"{foo: 1, bar: 2}"`) to be treated as a single argument; unquoted objects will split at their internal commas
  - Parsing rules: Arguments are split at commas unless the comma is escaped, inside quotes, or inside a regexp

  The changes improve parsing accuracy for complex scriptlet arguments and include reorganized tests that demonstrate the correct syntax for object literals and escaped comma behavior. This ensures scriptlets with sophisticated arguments are parsed as intended.