### PR TITLE
chore(ci): set `versioning-strategy` to `increase`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,7 @@ updates:
     schedule:
       interval: daily
       time: "04:00"
+    versioning-strategy: increase
     open-pull-requests-limit: 99
     labels:
       - "PR: Dependencies :nut_and_bolt:"


### PR DESCRIPTION
The current dependabot behaviour doesn't affect to the version strings in `package.json`. The dependencies are updated only in lockfile. It's still effective to prevent some very critical vulnerabilities but I don't think there's a sense of keeping the dependency version in `package.json` for us.

From #5220 , I noticed that many packages we're depending on are heavily outdated looking at `package.json`. If many of them heavily changed the API, it'd be quite a work to migrate all code base. Instead, I expect increasing the version string in `package.json` will distribute those workload. Also, it's important to keep the supported version range with our ecosystem platforms like electron, playwright, and puppeteer for security and performance.

Dependabot will still run at daily basis as it will close outdated pull request automatically.