### PR TITLE
fix: `matchCosmeticFilters` should report generic hide exceptions

### DIFF
--- a/packages/adblocker/src/engine/engine.ts
+++ b/packages/adblocker/src/engine/engine.ts
@@ -47,7 +47,7 @@ function shouldApplyHideException(filters: NetworkFilter[]): NetworkFilter | und
 
   // Get $Xhide filter with highest priority:
   // $Xhide,important > $Xhide > @@$Xhide
-  let genericHideFilter: NetworkFilter | undefined;
+  let hideFilter: NetworkFilter | undefined;
   let currentScore = 0;
   for (const filter of filters) {
     // To encode priority between filters, we create a bitmask with the following:
@@ -59,20 +59,20 @@ function shouldApplyHideException(filters: NetworkFilter[]): NetworkFilter | und
     // Highest `score` has precedence
     if (score >= currentScore) {
       currentScore = score;
-      genericHideFilter = filter;
+      hideFilter = filter;
     }
   }
 
-  if (genericHideFilter === undefined) {
+  if (hideFilter === undefined) {
     return;
   }
 
   // Check that there is at least one $generichide match and no exception
-  if (genericHideFilter.isException() === false) {
+  if (hideFilter.isException() === false) {
     return;
   }
 
-  return genericHideFilter;
+  return hideFilter;
 }
 
 export interface BlockingResponse {

--- a/packages/adblocker/src/engine/engine.ts
+++ b/packages/adblocker/src/engine/engine.ts
@@ -1247,7 +1247,9 @@ export default class FilterEngine extends EventEmitter<EngineEventHandlers> {
         filter: undefined,
         exception: genericHideException,
       });
-    } else if (specificHideException !== undefined) {
+    }
+
+    if (specificHideException !== undefined) {
       matches.push({
         filter: undefined,
         exception: specificHideException,

--- a/packages/adblocker/src/engine/engine.ts
+++ b/packages/adblocker/src/engine/engine.ts
@@ -1209,8 +1209,8 @@ export default class FilterEngine extends EventEmitter<EngineEventHandlers> {
     const genericHides: NetworkFilter[] = [];
     const specificHides: NetworkFilter[] = [];
     for (const filter of exceptions) {
-      // A filter is classified as $elemhide when bits for $ghide and $shide are both enabled.
-      // $elemhide is treated as both $ghide and $shide here to calculate the priority later on.
+      // A filter can be both specific ($shide) and generic ($ghide).
+      // In that case, it is an $elemhide, and we have to consider both cases here to calculate the priority later on.
       if (filter.isSpecificHide()) {
         specificHides.push(filter);
       }

--- a/packages/adblocker/src/engine/engine.ts
+++ b/packages/adblocker/src/engine/engine.ts
@@ -1240,7 +1240,11 @@ export default class FilterEngine extends EventEmitter<EngineEventHandlers> {
       });
     }
 
-    if (specificHideException !== undefined) {
+    if (
+      specificHideException !== undefined &&
+      // The filter can be $elemhide which get set both for ghide and shide
+      genericHideException !== specificHideException
+    ) {
       matches.push({
         filter: undefined,
         exception: specificHideException,

--- a/packages/adblocker/src/engine/engine.ts
+++ b/packages/adblocker/src/engine/engine.ts
@@ -1180,12 +1180,12 @@ export default class FilterEngine extends EventEmitter<EngineEventHandlers> {
   }): {
     matches: (
       | {
-          filter: CosmeticFilter | undefined;
+          filter: CosmeticFilter;
           exception: CosmeticFilter | undefined;
         }
       | {
           filter: undefined;
-          exception: NetworkFilter | undefined;
+          exception: NetworkFilter;
         }
     )[];
     allowGenericHides: boolean;

--- a/packages/adblocker/src/engine/engine.ts
+++ b/packages/adblocker/src/engine/engine.ts
@@ -1192,16 +1192,7 @@ export default class FilterEngine extends EventEmitter<EngineEventHandlers> {
   } {
     domain ||= '';
 
-    const matches: (
-      | {
-          filter: CosmeticFilter | undefined;
-          exception: CosmeticFilter | undefined;
-        }
-      | {
-          filter: undefined;
-          exception: NetworkFilter | undefined;
-        }
-    )[] = [];
+    const matches: ReturnType<FilterEngine['matchCosmeticFilters']>['matches'] = [];
     let genericHideException: NetworkFilter | undefined;
     let specificHideException: NetworkFilter | undefined;
 

--- a/packages/adblocker/src/engine/engine.ts
+++ b/packages/adblocker/src/engine/engine.ts
@@ -1209,7 +1209,8 @@ export default class FilterEngine extends EventEmitter<EngineEventHandlers> {
     const genericHides: NetworkFilter[] = [];
     const specificHides: NetworkFilter[] = [];
     for (const filter of exceptions) {
-      // $elemhide is expressed as both ghide and shide enabled together
+      // A filter is classified as $elemhide when bits for $ghide and $shide are both enabled.
+      // $elemhide is treated as both $ghide and $shide here to calculate the priority later on.
       if (filter.isSpecificHide()) {
         specificHides.push(filter);
       }

--- a/packages/adblocker/src/engine/engine.ts
+++ b/packages/adblocker/src/engine/engine.ts
@@ -1193,9 +1193,6 @@ export default class FilterEngine extends EventEmitter<EngineEventHandlers> {
     domain ||= '';
 
     const matches: ReturnType<FilterEngine['matchCosmeticFilters']>['matches'] = [];
-    let genericHideException: NetworkFilter | undefined;
-    let specificHideException: NetworkFilter | undefined;
-
     const exceptions = this.hideExceptions.matchAll(
       Request.fromRawDetails({
         domain,
@@ -1212,26 +1209,17 @@ export default class FilterEngine extends EventEmitter<EngineEventHandlers> {
     const genericHides: NetworkFilter[] = [];
     const specificHides: NetworkFilter[] = [];
     for (const filter of exceptions) {
-      if (filter.isElemHide()) {
-        genericHideException = filter;
-        specificHideException = filter;
-        break;
-      }
-
+      // $elemhide is expressed as both ghide and shide enabled together
       if (filter.isSpecificHide()) {
         specificHides.push(filter);
-      } else if (filter.isGenericHide()) {
+      }
+      if (filter.isGenericHide()) {
         genericHides.push(filter);
       }
     }
 
-    if (genericHideException === undefined) {
-      genericHideException = shouldApplyHideException(genericHides);
-    }
-
-    if (specificHideException === undefined) {
-      specificHideException = shouldApplyHideException(specificHides);
-    }
+    const genericHideException = shouldApplyHideException(genericHides);
+    const specificHideException = shouldApplyHideException(specificHides);
 
     if (genericHideException !== undefined) {
       matches.push({

--- a/packages/adblocker/src/engine/engine.ts
+++ b/packages/adblocker/src/engine/engine.ts
@@ -1223,9 +1223,15 @@ export default class FilterEngine extends EventEmitter<EngineEventHandlers> {
     const specificHideException = findApplicableHideException(specificHides);
 
     if (genericHideException !== undefined) {
-      matches.push({
+      const match = {
         filter: undefined,
         exception: genericHideException,
+      };
+      matches.push(match);
+      this.emit('filter-matched', match, {
+        url,
+        callerContext,
+        filterType: FilterType.COSMETIC,
       });
     }
 
@@ -1234,9 +1240,15 @@ export default class FilterEngine extends EventEmitter<EngineEventHandlers> {
       // The filter can be $elemhide which get set both for ghide and shide
       genericHideException !== specificHideException
     ) {
-      matches.push({
+      const match = {
         filter: undefined,
         exception: specificHideException,
+      };
+      matches.push(match);
+      this.emit('filter-matched', match, {
+        url,
+        callerContext,
+        filterType: FilterType.COSMETIC,
       });
     }
 

--- a/packages/adblocker/src/engine/engine.ts
+++ b/packages/adblocker/src/engine/engine.ts
@@ -40,7 +40,7 @@ import { IPattern } from './metadata/patterns.js';
 
 export const ENGINE_VERSION = 811;
 
-function shouldApplyHideException(filters: NetworkFilter[]): NetworkFilter | undefined {
+function findApplicableHideException(filters: NetworkFilter[]): NetworkFilter | undefined {
   if (filters.length === 0) {
     return;
   }
@@ -1219,8 +1219,8 @@ export default class FilterEngine extends EventEmitter<EngineEventHandlers> {
       }
     }
 
-    const genericHideException = shouldApplyHideException(genericHides);
-    const specificHideException = shouldApplyHideException(specificHides);
+    const genericHideException = findApplicableHideException(genericHides);
+    const specificHideException = findApplicableHideException(specificHides);
 
     if (genericHideException !== undefined) {
       matches.push({

--- a/packages/adblocker/test/engine/engine.test.ts
+++ b/packages/adblocker/test/engine/engine.test.ts
@@ -1816,7 +1816,7 @@ foo.com###selector
     );
   });
 
-  describe.only('#matchCosmeticFilters', () => {
+  describe('#matchCosmeticFilters', () => {
     it('reports specific hide exception', () => {
       const engine = FilterEngine.parse(`
         ###ad

--- a/packages/adblocker/test/engine/engine.test.ts
+++ b/packages/adblocker/test/engine/engine.test.ts
@@ -1849,13 +1849,18 @@ foo.com###selector
         getRulesFromDOM: true,
       });
       expect(matches.length).to.be.eql(2);
-      for (const match of matches) {
-        expect(match.filter).to.be.undefined;
-        expect(match.exception).to.satisfy(
-          (filter: NetworkFilter) =>
-            (filter.isGenericHide() || filter.isSpecificHide()) && filter.isException(),
-        );
-      }
+      const match1 = matches[0];
+      expect(match1.filter).to.be.undefined;
+      expect(match1.exception).to.satisfy(
+        (filter: NetworkFilter) =>
+          (filter.isGenericHide() || filter.isSpecificHide()) && filter.isException(),
+      );
+      const match2 = matches[1];
+      expect(match2.filter).to.be.undefined;
+      expect(match2.exception).to.satisfy(
+        (filter: NetworkFilter) =>
+          (filter.isGenericHide() || filter.isSpecificHide()) && filter.isException(),
+      );
     });
   });
 

--- a/packages/adblocker/test/engine/engine.test.ts
+++ b/packages/adblocker/test/engine/engine.test.ts
@@ -1862,6 +1862,26 @@ foo.com###selector
           (filter.isGenericHide() || filter.isSpecificHide()) && filter.isException(),
       );
     });
+
+    it('report `$elemhide` as a singular exception', () => {
+      const engine = FilterEngine.parse(`
+        ###ad
+        @@||foo.com^$elemhide
+      `);
+      const { matches } = engine.matchCosmeticFilters({
+        url: 'https://foo.com',
+        hostname: 'foo.com',
+        domain: 'foo.com',
+        classes: ['ad'],
+        getRulesFromDOM: true,
+      });
+      expect(matches.length).to.be.eql(1);
+      const match = matches[0];
+      expect(match.filter).to.be.undefined;
+      expect(match.exception).to.satisfy(
+        (filter: NetworkFilter) => filter.isElemHide() && filter.isException(),
+      );
+    });
   });
 
   describe('#getHtmlFilters', () => {

--- a/packages/adblocker/test/engine/engine.test.ts
+++ b/packages/adblocker/test/engine/engine.test.ts
@@ -1814,6 +1814,21 @@ foo.com###selector
     );
   });
 
+  describe('#matchCosmeticFilters', () => {
+    it('reports generic hide exceptions', () => {
+      const engine = FilterEngine.parse('###ad\n@@||foo.com^$generichide');
+      const { matches } = engine.matchCosmeticFilters({
+        url: 'https://foo.com',
+        hostname: 'foo.com',
+        domain: 'foo.com',
+        classes: ['ad'],
+        getRulesFromDOM: true,
+      });
+      expect(matches.length).to.be.eql(1);
+      expect(matches[0].exception).not.to.be.undefined;
+    });
+  });
+
   describe('#getHtmlFilters', () => {
     const config = {
       enableHtmlFiltering: true,

--- a/packages/adblocker/test/engine/engine.test.ts
+++ b/packages/adblocker/test/engine/engine.test.ts
@@ -1825,7 +1825,9 @@ foo.com###selector
         getRulesFromDOM: true,
       });
       expect(matches.length).to.be.eql(1);
-      expect(matches[0].exception).not.to.be.undefined;
+      expect(matches[0].exception?.isNetworkFilter()).to.be.true;
+      expect(matches[0].exception!.isGenericHide()).to.be.true;
+      expect((matches[0].exception as NetworkFilter).isException()).to.be.true;
     });
   });
 

--- a/packages/adblocker/test/engine/engine.test.ts
+++ b/packages/adblocker/test/engine/engine.test.ts
@@ -2414,4 +2414,58 @@ describe('events', () => {
     expect(filter!.toString()).to.be.equal('||bar.com');
     expect(exception!.toString()).to.be.equal('@@||bar.com');
   });
+
+  it('emits generichide exceptions in filter-matched', async () => {
+    const generichide = '@@||bar.com^$generichide';
+    const engine = createEngine(generichide);
+    const awaiter = createEventAwaiter(engine, 'filter-matched');
+
+    engine.matchCosmeticFilters({
+      url: 'https://bar.com',
+      hostname: 'bar.com',
+      domain: 'bar.com',
+      getRulesFromDOM: true,
+    });
+
+    const [[{ filter, exception }]] = await awaiter;
+
+    expect(filter).to.be.undefined;
+    expect(exception!.toString()).to.be.equal(generichide);
+  });
+
+  it('emits specifichide exceptions in filter-matched', async () => {
+    const specifichide = '@@||bar.com^$generichide';
+    const engine = createEngine(specifichide);
+    const awaiter = createEventAwaiter(engine, 'filter-matched');
+
+    engine.matchCosmeticFilters({
+      url: 'https://bar.com',
+      hostname: 'bar.com',
+      domain: 'bar.com',
+      getRulesFromDOM: true,
+    });
+
+    const [[{ filter, exception }]] = await awaiter;
+
+    expect(filter).to.be.undefined;
+    expect(exception!.toString()).to.be.equal(specifichide);
+  });
+
+  it('emits elemhide exceptions in filter-matched', async () => {
+    const elemhide = '@@||bar.com^$elemhide';
+    const engine = createEngine(elemhide);
+    const awaiter = createEventAwaiter(engine, 'filter-matched');
+
+    engine.matchCosmeticFilters({
+      url: 'https://bar.com',
+      hostname: 'bar.com',
+      domain: 'bar.com',
+      getRulesFromDOM: true,
+    });
+
+    const [[{ filter, exception }]] = await awaiter;
+
+    expect(filter).to.be.undefined;
+    expect(exception!.toString()).to.be.equal(elemhide);
+  });
 });

--- a/packages/adblocker/test/engine/engine.test.ts
+++ b/packages/adblocker/test/engine/engine.test.ts
@@ -1824,7 +1824,7 @@ foo.com###selector
         url: 'https://foo.com',
         hostname: 'foo.com',
         domain: 'foo.com',
-        classes: ['ad'],
+        ids: ['ad'],
         getRulesFromDOM: true,
       });
       expect(matches.length).to.be.eql(1);
@@ -1845,7 +1845,7 @@ foo.com###selector
         url: 'https://foo.com',
         hostname: 'foo.com',
         domain: 'foo.com',
-        classes: ['ad'],
+        ids: ['ad'],
         getRulesFromDOM: true,
       });
       expect(matches.length).to.be.eql(2);
@@ -1870,7 +1870,7 @@ foo.com###selector
         url: 'https://foo.com',
         hostname: 'foo.com',
         domain: 'foo.com',
-        classes: ['ad'],
+        ids: ['ad'],
         getRulesFromDOM: true,
       });
       expect(matches.length).to.be.eql(1);

--- a/packages/adblocker/test/engine/engine.test.ts
+++ b/packages/adblocker/test/engine/engine.test.ts
@@ -1852,14 +1852,12 @@ foo.com###selector
       const match1 = matches[0];
       expect(match1.filter).to.be.undefined;
       expect(match1.exception).to.satisfy(
-        (filter: NetworkFilter) =>
-          (filter.isGenericHide() || filter.isSpecificHide()) && filter.isException(),
+        (filter: NetworkFilter) => filter.isGenericHide() && filter.isException(),
       );
       const match2 = matches[1];
       expect(match2.filter).to.be.undefined;
       expect(match2.exception).to.satisfy(
-        (filter: NetworkFilter) =>
-          (filter.isGenericHide() || filter.isSpecificHide()) && filter.isException(),
+        (filter: NetworkFilter) => filter.isSpecificHide() && filter.isException(),
       );
     });
 


### PR DESCRIPTION
fixes #5229

- Extends return type `matches` to include `NetworkFilter` as generic hide exception is a "network filter".
- Changes return type of `shouldApplyHideException` to `NetworkFilter` or `undefined` to comply with flow of `matchCosmeticFilters`.